### PR TITLE
Kotlin 1.2 upgrade

### DIFF
--- a/src/lib/kotlin/build.gradle
+++ b/src/lib/kotlin/build.gradle
@@ -79,8 +79,10 @@ subprojects { project ->
 
     // gradle -Puser=someuser -Pkey=ASDFASDFASDF bintrayUpload
 	bintray {
-        user = property('user')
-        key = property('key')
+        //user = property('user')
+        //key = property('key')
+        user = project.hasProperty('bintrayUser') ? project.property('bintrayUser') : System.getenv('BINTRAY_USER')
+        key = project.hasProperty('bintrayApiKey') ? project.property('bintrayApiKey') : System.getenv('BINTRAY_API_KEY')
 		publish = true
         configurations = ['archives']
         pkg {

--- a/src/lib/kotlin/settings.gradle
+++ b/src/lib/kotlin/settings.gradle
@@ -1,1 +1,1 @@
-include 'slatekit-common', 'slatekit-meta', 'slatekit-entities', 'slatekit-core', 'slatekit-apis', 'slatekit-integration', 'slatekit-cloud', 'slatekit-server'
+include 'slatekit-common', 'slatekit-meta', 'slatekit-entities', 'slatekit-core', 'slatekit-apis', 'slatekit-integration', 'slatekit-cloud', 'slatekit-server', 'slatekit-tools'

--- a/src/lib/kotlin/slatekit-apis/build.gradle
+++ b/src/lib/kotlin/slatekit-apis/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'kotlin'
 
 
 buildscript {
-    ext.kotlin_version = '1.1.2'
+    ext.kotlin_version = '1.2.31'
 
     repositories {
         mavenCentral()
@@ -22,7 +22,7 @@ repositories {
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compile "com.googlecode.json-simple:json-simple:1.1"
     compile project(":slatekit-common")
     compile project(":slatekit-meta")

--- a/src/lib/kotlin/slatekit-cloud/build.gradle
+++ b/src/lib/kotlin/slatekit-cloud/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'kotlin'
 
 
 buildscript {
-    ext.kotlin_version = '1.1.2'
+    ext.kotlin_version = '1.2.31'
 
     repositories {
         mavenCentral()
@@ -22,7 +22,7 @@ repositories {
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 	compile fileTree(dir: 'lib', include: '*.jar')
 	compile "com.amazonaws:aws-java-sdk-core:1.11.100"
     compile "com.amazonaws:aws-java-sdk-s3:1.11.100"

--- a/src/lib/kotlin/slatekit-common/build.gradle
+++ b/src/lib/kotlin/slatekit-common/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'java'
 apply plugin: 'kotlin'
 
 buildscript {
-    ext.kotlin_version = '1.1.2'
+    ext.kotlin_version = '1.2.31'
 
     repositories {
         mavenCentral()
@@ -21,6 +21,6 @@ repositories {
 
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 }
 

--- a/src/lib/kotlin/slatekit-core/build.gradle
+++ b/src/lib/kotlin/slatekit-core/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'kotlin'
 
 
 buildscript {
-    ext.kotlin_version = '1.1.2'
+    ext.kotlin_version = '1.2.31'
 
     repositories {
         mavenCentral()
@@ -22,7 +22,7 @@ repositories {
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compile project(":slatekit-common")
     compile project(":slatekit-meta")
 }

--- a/src/lib/kotlin/slatekit-entities/build.gradle
+++ b/src/lib/kotlin/slatekit-entities/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'kotlin'
 
 
 buildscript {
-    ext.kotlin_version = '1.1.2'
+    ext.kotlin_version = '1.2.31'
 
     repositories {
         mavenCentral()
@@ -22,7 +22,7 @@ repositories {
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compile project(":slatekit-common")
     compile project(":slatekit-meta")
 }

--- a/src/lib/kotlin/slatekit-examples/build.gradle
+++ b/src/lib/kotlin/slatekit-examples/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'kotlin'
 
 
 buildscript {
-    ext.kotlin_version = '1.1.2'
+    ext.kotlin_version = '1.2.31'
 
     repositories {
         mavenCentral()
@@ -22,7 +22,7 @@ repositories {
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compile "com.googlecode.json-simple:json-simple:1.1"
     compile project(":slatekit-common")
     compile project(":slatekit-meta")

--- a/src/lib/kotlin/slatekit-integration/build.gradle
+++ b/src/lib/kotlin/slatekit-integration/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'kotlin'
 
 
 buildscript {
-    ext.kotlin_version = '1.1.2'
+    ext.kotlin_version = '1.2.31'
 
     repositories {
         mavenCentral()
@@ -22,7 +22,7 @@ repositories {
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compile "com.googlecode.json-simple:json-simple:1.1"
     compile project(":slatekit-common")
     compile project(":slatekit-meta")

--- a/src/lib/kotlin/slatekit-meta/build.gradle
+++ b/src/lib/kotlin/slatekit-meta/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'kotlin'
 
 
 buildscript {
-    ext.kotlin_version = '1.1.2'
+    ext.kotlin_version = '1.2.31'
 
     repositories {
         mavenCentral()
@@ -22,7 +22,7 @@ repositories {
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compile "com.googlecode.json-simple:json-simple:1.1"
     compile project(":slatekit-common")
 }

--- a/src/lib/kotlin/slatekit-server/build.gradle
+++ b/src/lib/kotlin/slatekit-server/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'kotlin'
 
 
 buildscript {
-    ext.kotlin_version = '1.1.2'
+    ext.kotlin_version = '1.2.31'
 
     repositories {
         mavenCentral()
@@ -22,7 +22,7 @@ repositories {
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compile "com.googlecode.json-simple:json-simple:1.1"
     compile 'com.sparkjava:spark-core:2.6.0'
     compile 'org.slf4j:slf4j-simple:1.7.25'

--- a/src/lib/kotlin/slatekit-tests/build.gradle
+++ b/src/lib/kotlin/slatekit-tests/build.gradle
@@ -1,6 +1,6 @@
 
 buildscript {
-    ext.kotlin_version = '1.1.2-2'
+    ext.kotlin_version = '1.2.31'
 
     repositories {
         mavenCentral()
@@ -27,7 +27,7 @@ repositories {
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compile "mysql:mysql-connector-java:5.1.13"
     compile project(":slatekit-common")
     compile project(":slatekit-meta")

--- a/src/lib/kotlin/slatekit-tests/settings.gradle
+++ b/src/lib/kotlin/slatekit-tests/settings.gradle
@@ -20,6 +20,3 @@ project(':slatekit-integration').projectDir=new File('../slatekit-integration')
 
 include ':slatekit-cloud'
 project(':slatekit-cloud').projectDir=new File('../slatekit-cloud')
-
-include ':slatekit-ext'
-project(':slatekit-ext').projectDir=new File('../slatekit-ext')

--- a/src/lib/kotlin/slatekit-tests/src/main/resources/db_setup.sql
+++ b/src/lib/kotlin/slatekit-tests/src/main/resources/db_setup.sql
@@ -1,4 +1,6 @@
 
+drop table if exists `db_tests`;
+
 CREATE TABLE `db_tests` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `test_string` varchar(50) NOT NULL,

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/common/ConfigTests.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/common/ConfigTests.kt
@@ -144,7 +144,7 @@ class ConfigTests {
 
 
     @Test fun test_loading_from_dir_explicit() {
-        val conf  = Config("file:///Users/kishore.reddy/.slatekit/conf/env.conf")
+        val conf  = Config("file:///Users/kishorereddy/.slatekit/conf/env.conf")
         val key = conf.apiLogin("aws-sqs")
         matchkey(key, ApiLogin("mycompany1.dev", "key1", "pass1", "env1", "tag1"))
     }

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/db/DbTests.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/db/DbTests.kt
@@ -51,7 +51,7 @@ class DbTests {
 
 
     @Test fun can_query_scalar_localdate() {
-        ensure_scalar("test_localdate", { db, sql -> db.getScalarLocalDate(sql) }, LocalDate.of(2017, 7, 6) )
+        ensure_scalar("test_localdate", { db, sql -> db.getScalarLocalDate(sql) }, LocalDate.of(2017, 6, 1) )
     }
 
 
@@ -73,13 +73,13 @@ class DbTests {
     @Test fun can_execute_proc() {
         val db = Db(con!!)
         val result = db.callQuery("dbtests_get_max_id", { rs -> rs.getLong(1) } )
-        assert(result!! > 3L)
+        assert(result!! > 0L)
     }
 
 
     @Test fun can_execute_proc_update() {
         val db = Db(con!!)
-        val result = db.callUpdate("dbtests_update_by_id", listOf(8) )
+        val result = db.callUpdate("dbtests_update_by_id", listOf(6) )
         assert(result!! >= 1)
     }
 

--- a/src/lib/kotlin/slatekit-tools/build.gradle
+++ b/src/lib/kotlin/slatekit-tools/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'kotlin'
 
 
 buildscript {
-    ext.kotlin_version = '1.1.2'
+    ext.kotlin_version = '1.2.31'
 
     repositories {
         mavenCentral()
@@ -22,7 +22,7 @@ repositories {
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compile project(":slatekit-common")
     compile project(":slatekit-meta")
     compile project(":slatekit-entities")


### PR DESCRIPTION
# Overview
Upgrade to Kotlin 1.2 and minor fixes

# Changes
- All build.gradle files now reference kotlin plugin 1.2.31 
- Settings file changed to now include slatekit-tools project
- Minor fixes to unit-tests

# Notes
- Code formatting ( using kotlin coding conventions ) and auto-formatting will be setup in a separate PR ( as many files will be changed )