### PR TITLE
ORM encryption support

### DIFF
--- a/src/lib/kotlin/slatekit-entities/src/main/kotlin/slatekit/entities/core/EntityMapper.kt
+++ b/src/lib/kotlin/slatekit-entities/src/main/kotlin/slatekit/entities/core/EntityMapper.kt
@@ -103,7 +103,7 @@ open class EntityMapper(model: Model, persistAsUtc:Boolean = false, encryptor:En
                 val sVal = Reflector.getFieldValue(item, mapping.name) as String?
                 sVal?.let {
                     // Only encrypt on create
-                    val sValEnc = if (!update && mapping.encrypt) _encryptor?.encrypt(sVal) ?: sVal else sVal
+                    val sValEnc = if (mapping.encrypt) _encryptor?.encrypt(sVal) ?: sVal else sVal
                     val sValFinal = sValEnc.nonEmptyOrDefault("")
                 "'" + QueryEncoder.ensureValue(sValFinal) + "'"
                 } ?: NULL

--- a/src/lib/kotlin/slatekit-meta/src/main/kotlin/slatekit/meta/models/ModelMapper.kt
+++ b/src/lib/kotlin/slatekit-meta/src/main/kotlin/slatekit/meta/models/ModelMapper.kt
@@ -204,7 +204,7 @@ open class ModelMapper(protected val _model: Model,
     private fun getDataValue(prefix:String?, mapping:ModelField, record:Record, isUTC:Boolean): Any? {
         val colName = prefix?.let { prefix + mapping.storedName } ?: mapping.storedName
         val dataValue = when (mapping.dataCls) {
-            KTypes.KStringClass        -> record.getString(colName)
+            KTypes.KStringClass        -> getString(record, mapping, colName, _encryptor)
             KTypes.KBoolClass          -> record.getBool(colName)
             KTypes.KShortClass         -> record.getShort(colName)
             KTypes.KIntClass           -> record.getInt(colName)
@@ -231,5 +231,16 @@ open class ModelMapper(protected val _model: Model,
             }
         }
         return dataValue
+    }
+
+
+    @Suppress("NOTHING_TO_INLINE")
+    inline fun getString(record:Record, mapping:ModelField, colName:String, encryptor:Encryptor?): String? {
+        return if(mapping.encrypt) {
+            val text = record.getString(colName)
+            text?.let { raw -> encryptor?.let{ it.decrypt( raw ) } ?: raw }
+        } else {
+            record.getString(colName)
+        }
     }
 }

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/entities/Entity_Database_Tests.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/entities/Entity_Database_Tests.kt
@@ -19,6 +19,7 @@ import slatekit.common.conf.ConfFuncs
 import slatekit.common.db.DbLookup
 import slatekit.common.db.DbTypeMySql
 import slatekit.entities.core.*
+import test.setup.MyEncryptor
 import test.setup.StatusEnum
 import java.util.*
 
@@ -35,6 +36,7 @@ class Entity_Database_Tests {
     create table `sample_entity` (
         `id` BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
         `test_string` VARCHAR(30) NOT NULL,
+        `test_string_enc` VARCHAR(100) NOT NULL,
         `test_bool` BIT NOT NULL,
         `test_short` TINYINT NOT NULL,
         `test_int` INTEGER NOT NULL,
@@ -46,8 +48,7 @@ class Entity_Database_Tests {
         `test_localtime` TIME NOT NULL,
         `test_localdatetime` DATETIME NOT NULL,
         `test_uuid` VARCHAR(50) NOT NULL,
-        `test_uniqueId` VARCHAR(50) NOT NULL
-    );
+        `test_uniqueId` VARCHAR(50) NOT NULL );
     */
 
     @Test fun can_use_all_types(): Unit {
@@ -59,6 +60,7 @@ class Entity_Database_Tests {
 
         val id = svc.create(SampleEntity(
                 test_string = "create",
+                test_string_enc = "original 123 v1",
                 test_bool   = false,
                 test_short  = 123,
                 test_int    = 1234,
@@ -76,6 +78,7 @@ class Entity_Database_Tests {
         val created = svc.get(id)
         val update = created!!.copy(
                 test_string = "update",
+                test_string_enc = "original 123 v2",
                 test_bool   = true,
                 test_short  = 124,
                 test_int    = 21234,
@@ -94,6 +97,7 @@ class Entity_Database_Tests {
         val updated = svc.get(id)!!
         assert(updated.id == update.id)
         assert(updated.test_string == update.test_string)
+        assert(updated.test_string_enc == update.test_string_enc)
         assert(updated.test_bool == update.test_bool)
         assert(updated.test_short == update.test_short)
         assert(updated.test_int == update.test_int)
@@ -110,7 +114,7 @@ class Entity_Database_Tests {
 
     private fun realDb(): Entities {
         val dbs = DbLookup.defaultDb(con!!)
-        val entities = Entities(dbs)
+        val entities = Entities(dbs, MyEncryptor)
         entities.register<SampleEntity>(true, SampleEntity::class, dbType = DbTypeMySql, tableName = "sample_entity")
         return entities
     }
@@ -149,6 +153,9 @@ class Entity_Database_Tests {
 
             @property:Field(length = 30, required = true)
             val test_string:String = "",
+
+            @property:Field(length = 100, encrypt = true)
+            val test_string_enc:String = "",
 
             @property:Field()
             val test_bool:Boolean = false,


### PR DESCRIPTION
# Overview
This provides support for automatic encryption of strings when setting the `encrypt` flag to true on the annotation of the persisted field.

# Changes
1. This handles the encryption of the field just before saving for both creates/updates
2. This handles the decryption of the field when loading the field from the DB

# Notes
1. The length of the encrypted text will be more than the length of the raw text. However, this fix ( at the moment ) does not account for/validate the length of the column w/ the length of the encrypted text.
2. At the moment, the end-user of the component must ensure the length of the field is set to a number large enough to hold the encrypted value.