### PR TITLE
ORM: Support for getting entities by UUIDs

### DIFF
--- a/src/lib/kotlin/slatekit-entities/src/main/kotlin/slatekit/entities/core/IEntity.kt
+++ b/src/lib/kotlin/slatekit-entities/src/main/kotlin/slatekit/entities/core/IEntity.kt
@@ -90,17 +90,18 @@ interface EntityWithTime {
 
 /**
  * Entity with support for create/update user id
+ * NOTE: This ids can be either long/UUID, so making this type a string to support either
  */
 interface EntityWithUser {
-    val createdBy: Long
-    val updatedBy: Long
+    val createdBy: String
+    val updatedBy: String
 }
 
 
 /**
  * Entity with support for a unique id ( GUID )
  */
-interface EntityWithGuid {
+interface EntityWithUUID {
     val uuid: String
 }
 
@@ -129,7 +130,7 @@ interface EntityWithShard {
 interface EntityWithMeta
     : EntityWithTime
       , EntityWithUser
-      , EntityWithGuid {
+      , EntityWithUUID {
 }
 
 

--- a/src/lib/kotlin/slatekit-entities/src/main/kotlin/slatekit/entities/services/EntityUUID.kt
+++ b/src/lib/kotlin/slatekit-entities/src/main/kotlin/slatekit/entities/services/EntityUUID.kt
@@ -1,0 +1,45 @@
+package slatekit.entities.services
+
+import slatekit.entities.core.Entity
+import slatekit.entities.core.EntityWithUUID
+import slatekit.entities.core.ServiceSupport
+import java.util.*
+
+
+/**
+ * NOTE: There is only 1 type constraint on the type parameter T to be Entity
+ * ( Which is needed for all the supporting scaffolding ), so we can NOT at the moment
+ * supply another type constraint on T to be EntityWithUUID to provide compile time safety.
+ *
+ */
+interface EntityUUID<T> : ServiceSupport<T> where T : Entity {
+
+    /**
+     * gets the entity from the datastore using the uuid as a string
+     * @param id
+     * @return
+     */
+    fun getByUUID(id: String): T? {
+        return entityRepo().findFirstBy(EntityWithUUID::uuid.name, "=", id)
+    }
+
+
+    /**
+     * gets the entity from the datastore using the uuid
+     * @param id
+     * @return
+     */
+    fun getByUUID(id: UUID): T? {
+        return entityRepo().findFirstBy(EntityWithUUID::uuid.name, "=", id.toString())
+    }
+
+
+    /**
+     * gets the entity from the datastore using the uuids
+     * @param id
+     * @return
+     */
+    fun getByUUIDs(ids: List<String>): List<T>? {
+        return entityRepo().findBy(EntityWithUUID::uuid.name, "in", ids)
+    }
+}

--- a/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Entities.kt
+++ b/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Entities.kt
@@ -66,7 +66,7 @@ class Example_Entities : Cmd("entities") {
                          override val createdBy : Long = 0,
                          override val uuid  : String = Random.guid()
                        )
-    : EntityWithId, EntityWithTime, EntityWithUser, EntityWithGuid
+    : EntityWithId, EntityWithTime, EntityWithUser, EntityWithUUID
   {
     // The unique id is a guid and unique regardless of environment ( dev, qa, staging, prod )
     // It serves as a easy way to check for existing items across different environments and

--- a/src/lib/kotlin/slatekit-integration/src/main/kotlin/slatekit/integration/errors/ErrorItem.kt
+++ b/src/lib/kotlin/slatekit-integration/src/main/kotlin/slatekit/integration/errors/ErrorItem.kt
@@ -80,16 +80,16 @@ data class ErrorItem(
         override val createdAt: DateTime = DateTime.now(),
 
 
-        @property:Field()
-        override val createdBy: Long = 0,
+        @property:Field(length = 50)
+        override val createdBy: String = "",
 
 
         @property:Field()
         override val updatedAt: DateTime = DateTime.now(),
 
 
-        @property:Field()
-        override val updatedBy: Long = 0
+        @property:Field(length = 50)
+        override val updatedBy: String = ""
 )
 
     : slatekit.entities.core.EntityWithId, slatekit.entities.core.EntityWithMeta,

--- a/src/lib/kotlin/slatekit-integration/src/main/kotlin/slatekit/integration/mods/Mod.kt
+++ b/src/lib/kotlin/slatekit-integration/src/main/kotlin/slatekit/integration/mods/Mod.kt
@@ -15,7 +15,7 @@ package slatekit.integration.mods
 
 import slatekit.common.DateTime
 import slatekit.common.Field
-import slatekit.entities.core.EntityWithGuid
+import slatekit.entities.core.EntityWithUUID
 import slatekit.entities.core.EntityWithId
 
 
@@ -79,5 +79,5 @@ data class Mod(
         @property:Field(length = 50)
         override val uuid: String = ""
 )
-    : EntityWithId, EntityWithGuid {
+    : EntityWithId, EntityWithUUID {
 }


### PR DESCRIPTION
# Overview
Improved support for ORM for getting entities by UUID/UUID string

# Changes
- added interface EntityUUID for methods to get by UUID
- switched createdAt/updatedAt to use String ( UUIDs )
