### PR TITLE
BUMP : slatekit.results to 0.9.9

### DIFF
--- a/src/lib/kotlin/slatekit-apis/build.gradle
+++ b/src/lib/kotlin/slatekit-apis/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compile "com.googlecode.json-simple:json-simple:1.1"
-    compile 'com.slatekit:slatekit-results:0.9.8'
+    compile 'com.slatekit:slatekit-results:0.9.9'
     compile project(":slatekit-common")
     compile project(":slatekit-meta")
 }

--- a/src/lib/kotlin/slatekit-app/build.gradle
+++ b/src/lib/kotlin/slatekit-app/build.gradle
@@ -37,6 +37,6 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 	compile fileTree(dir: 'lib', include: '*.jar')
-    compile 'com.slatekit:slatekit-results:0.9.8'
+    compile 'com.slatekit:slatekit-results:0.9.9'
     compile project(":slatekit-common")
 }

--- a/src/lib/kotlin/slatekit-app/src/main/kotlin/slatekit/app/AppContext.kt
+++ b/src/lib/kotlin/slatekit-app/src/main/kotlin/slatekit/app/AppContext.kt
@@ -24,6 +24,7 @@ import slatekit.common.envs.EnvMode
 import slatekit.common.info.*
 import slatekit.common.log.Logs
 import slatekit.common.log.LogsDefault
+import slatekit.results.StatusCodes
 
 /**
   *
@@ -63,13 +64,13 @@ data class AppContext(
     companion object {
 
         @JvmStatic
-        fun help(): AppContext = err(HELP.code)
+        fun help(): AppContext = err(StatusCodes.HELP.code)
 
         @JvmStatic
-        fun exit(): AppContext = err(EXIT.code)
+        fun exit(): AppContext = err(StatusCodes.EXIT.code)
 
         @JvmStatic
-        val empty: AppContext = err(HELP.code)
+        val empty: AppContext = err(StatusCodes.HELP.code)
 
         @JvmStatic
         fun err(code: Int, msg: String? = null): AppContext {

--- a/src/lib/kotlin/slatekit-app/src/main/kotlin/slatekit/app/AppFuncs.kt
+++ b/src/lib/kotlin/slatekit-app/src/main/kotlin/slatekit/app/AppFuncs.kt
@@ -26,10 +26,7 @@ import slatekit.common.encrypt.Encryptor
 import slatekit.common.envs.*
 import slatekit.common.info.*
 import slatekit.common.log.*
-import slatekit.results.Failure
-import slatekit.results.Notice
-import slatekit.results.Success
-import slatekit.results.flatMap
+import slatekit.results.*
 
 object AppFuncs {
 
@@ -58,19 +55,19 @@ object AppFuncs {
 
         // Case 1: Exit ?
         return if (isExit(raw, 0)) {
-            Success("exit", EXIT)
+            Success("exit", StatusCodes.EXIT)
         }
         // Case 2a: version ?
         else if (isVersion(raw, 0)) {
-            Success("version", VERSION)
+            Success("version", StatusCodes.VERSION)
         }
         // Case 2b: about ?
         else if (ArgsFuncs.isAbout(raw, 0)) {
-            Success("about", ABOUT)
+            Success("about", StatusCodes.ABOUT)
         }
         // Case 3a: Help ?
         else if ( ArgsFuncs.isHelp(raw, 0)) {
-            Success("help", HELP)
+            Success("help", StatusCodes.HELP)
         } else {
             Failure("other")
         }

--- a/src/lib/kotlin/slatekit-app/src/main/kotlin/slatekit/app/AppMeta.kt
+++ b/src/lib/kotlin/slatekit-app/src/main/kotlin/slatekit/app/AppMeta.kt
@@ -1,8 +1,5 @@
 package slatekit.app
 
-import slatekit.common.ABOUT
-import slatekit.common.HELP
-import slatekit.common.VERSION
 import slatekit.common.args.Args
 import slatekit.common.args.ArgsSchema
 import slatekit.common.info.About
@@ -38,9 +35,9 @@ class AppMeta(val ctx:AppContext, val args:ArgsSchema) {
     fun handle( check:Notice<String>) {
         if (check.success) {
             when(check.code) {
-                HELP.code    -> help()
-                ABOUT.code   -> about()
-                VERSION.code -> version()
+                StatusCodes.HELP.code    -> help()
+                StatusCodes.ABOUT.code   -> about()
+                StatusCodes.VERSION.code -> version()
                 else         -> println("Unexpected command: " + check.msg)
             }
         }

--- a/src/lib/kotlin/slatekit-cloud/build.gradle
+++ b/src/lib/kotlin/slatekit-cloud/build.gradle
@@ -39,7 +39,7 @@ dependencies {
 	compile "com.amazonaws:aws-java-sdk-core:1.11.100"
     compile "com.amazonaws:aws-java-sdk-s3:1.11.100"
     compile "com.amazonaws:aws-java-sdk-sqs:1.11.100"
-    compile 'com.slatekit:slatekit-results:0.9.8'
+    compile 'com.slatekit:slatekit-results:0.9.9'
     compile project(":slatekit-common")
     compile project(":slatekit-entities")
     compile project(":slatekit-core")

--- a/src/lib/kotlin/slatekit-common/build.gradle
+++ b/src/lib/kotlin/slatekit-common/build.gradle
@@ -16,8 +16,8 @@ buildscript {
 
 
 compileKotlin {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_1_6
+    targetCompatibility = JavaVersion.VERSION_1_6
 
     kotlinOptions {
         jvmTarget = "1.8"
@@ -39,8 +39,8 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compile 'com.squareup.okhttp3:okhttp:3.9.0'
-    compile 'com.slatekit:slatekit-results:0.9.8'
+    compile 'com.slatekit:slatekit-results:0.9.9'
+    compile 'org.threeten:threetenbp:1.3.8'
     //compile 'joda-time:joda-time:2.10.1'
-    //compile 'org.threeten.threetenbp:1.3.8'
 }
 

--- a/src/lib/kotlin/slatekit-common/build.gradle
+++ b/src/lib/kotlin/slatekit-common/build.gradle
@@ -40,5 +40,7 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compile 'com.squareup.okhttp3:okhttp:3.9.0'
     compile 'com.slatekit:slatekit-results:0.9.8'
+    //compile 'joda-time:joda-time:2.10.1'
+    //compile 'org.threeten.threetenbp:1.3.8'
 }
 

--- a/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/ResultExt.kt
+++ b/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/ResultExt.kt
@@ -19,30 +19,3 @@ fun <T, E> slatekit.results.Result<T, E>.toResponse(): Response<T> {
         }
     }
 }
-
-
-/**
- * Applies supplied function `f` if this is a [Success]
- *
- * @param f: the function to apply
- *
- * # Example
- * ```
- * val r1 = Success("Superman").flatMap { Success("Clark Kent") }  // Success("Clark Kent")
- * val r2 = Failure("Unknown" ).flatMap { Success("???")        }  // Failure("Unknown")
- * ```
- */
-inline fun <T1, T2, E> Result<T1, E>.then(f: (T1) -> Result<T2, E>): Result<T2, E> =
-        when (this) {
-            is Success -> f(this.value)
-            is Failure -> this
-        }
-
-
-fun <T,E> slatekit.results.Result<Result<T, E>,E>.inner(): Result<T,E> = this.fold( { it }, { Failure(it) } )
-
-val CONFIRM = StatusGroup.Pending(1010, "Confirm")
-val EXIT    = StatusGroup.Errored(4001, "Exiting")
-val HELP    = StatusGroup.Errored(4002, "Help")
-val ABOUT   = StatusGroup.Errored(4003, "About")
-val VERSION = StatusGroup.Errored(4004, "Version")

--- a/src/lib/kotlin/slatekit-core/build.gradle
+++ b/src/lib/kotlin/slatekit-core/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    compile 'com.slatekit:slatekit-results:0.9.8'
+    compile 'com.slatekit:slatekit-results:0.9.9'
     compile project(":slatekit-common")
     compile project(":slatekit-meta")
 }

--- a/src/lib/kotlin/slatekit-core/src/main/kotlin/slatekit/core/cli/CliFuncs.kt
+++ b/src/lib/kotlin/slatekit-core/src/main/kotlin/slatekit/core/cli/CliFuncs.kt
@@ -13,13 +13,12 @@
 
 package slatekit.core.cli
 
-import slatekit.common.EXIT
-import slatekit.common.HELP
 import slatekit.common.io.Files
 import slatekit.common.args.ArgsFuncs
 import slatekit.common.info.Folders
 import slatekit.results.Failure
 import slatekit.results.Notice
+import slatekit.results.StatusCodes
 import slatekit.results.Success
 
 object CliFuncs {
@@ -38,34 +37,34 @@ object CliFuncs {
 
         // Case 1: Exit ?
         return if (ArgsFuncs.isExit(words, 0)) {
-            Success(true,"exit", EXIT.code)
+            Success(true,"exit", StatusCodes.EXIT.code)
         }
         // Case 2a: version ?
         else if (ArgsFuncs.isVersion(words, 0)) {
-            Success(true,"version", HELP.code)
+            Success(true,"version", StatusCodes.HELP.code)
         }
         // Case 2b: about ?
         else if (ArgsFuncs.isAbout(words, 0)) {
-            Success(true,"about", HELP.code)
+            Success(true,"about", StatusCodes.HELP.code)
         }
         // Case 3a: Help ?
         else if (ArgsFuncs.isHelp(words, 0)) {
-            Success(true,"help", HELP.code)
+            Success(true,"help", StatusCodes.HELP.code)
         }
         // Case 3b: Help on area ?
         else if (ArgsFuncs.isHelp(verbs, 1)) {
-            Success(true,"area ?", HELP.code)
+            Success(true,"area ?", StatusCodes.HELP.code)
         }
         // Case 3c: Help on api ?
         else if (ArgsFuncs.isHelp(verbs, 2)) {
-            Success(true,"area.api ?", HELP.code)
+            Success(true,"area.api ?", StatusCodes.HELP.code)
         }
         // Case 3d: Help on action ?
         else if (!cmd.args.action.isNullOrEmpty() &&
                 (ArgsFuncs.isHelp(cmd.args.positional, 0) ||
                         ArgsFuncs.isHelp(verbs, 3))
                      ) {
-            Success(true, "area.api.action ?", HELP.code)
+            Success(true, "area.api.action ?", StatusCodes.HELP.code)
         } else
             Failure("")
     }

--- a/src/lib/kotlin/slatekit-core/src/main/kotlin/slatekit/core/cli/CliService.kt
+++ b/src/lib/kotlin/slatekit-core/src/main/kotlin/slatekit/core/cli/CliService.kt
@@ -135,7 +135,7 @@ open class CliService(
     fun tryLine(line: String): Boolean =
             try {
                 val result = onCommandExecute(line)
-                val isExit = result.code == slatekit.common.EXIT.code
+                val isExit = result.code == StatusCodes.EXIT.code
                 result.success || !isExit
             } catch (ex: Exception) {
                 display(null, ex)

--- a/src/lib/kotlin/slatekit-core/src/main/kotlin/slatekit/core/common/AppContext.kt
+++ b/src/lib/kotlin/slatekit-core/src/main/kotlin/slatekit/core/common/AppContext.kt
@@ -24,6 +24,7 @@ import slatekit.common.envs.EnvMode
 import slatekit.common.info.*
 import slatekit.common.log.Logs
 import slatekit.common.log.LogsDefault
+import slatekit.results.StatusCodes
 
 /**
   *
@@ -63,13 +64,13 @@ data class AppContext(
     companion object {
 
         @JvmStatic
-        fun help(): AppContext = err(HELP.code)
+        fun help(): AppContext = err(StatusCodes.HELP.code)
 
         @JvmStatic
-        fun exit(): AppContext = err(EXIT.code)
+        fun exit(): AppContext = err(StatusCodes.EXIT.code)
 
         @JvmStatic
-        val empty: AppContext = err(HELP.code)
+        val empty: AppContext = err(StatusCodes.HELP.code)
 
         @JvmStatic
         fun err(code: Int, msg: String? = null): AppContext {

--- a/src/lib/kotlin/slatekit-db/build.gradle
+++ b/src/lib/kotlin/slatekit-db/build.gradle
@@ -28,6 +28,6 @@ dependencies {
 	compile "com.amazonaws:aws-java-sdk-core:1.11.100"
     compile "com.amazonaws:aws-java-sdk-s3:1.11.100"
     compile "com.amazonaws:aws-java-sdk-sqs:1.11.100"
-    compile 'com.slatekit:slatekit-results:0.9.8'
+    compile 'com.slatekit:slatekit-results:0.9.9'
     compile project(":slatekit-common")
 }

--- a/src/lib/kotlin/slatekit-entities/build.gradle
+++ b/src/lib/kotlin/slatekit-entities/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    compile 'com.slatekit:slatekit-results:0.9.8'
+    compile 'com.slatekit:slatekit-results:0.9.9'
     compile project(":slatekit-common")
     compile project(":slatekit-meta")
     compile project(":slatekit-db")

--- a/src/lib/kotlin/slatekit-integration/build.gradle
+++ b/src/lib/kotlin/slatekit-integration/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compile "com.googlecode.json-simple:json-simple:1.1"
-    compile 'com.slatekit:slatekit-results:0.9.8'
+    compile 'com.slatekit:slatekit-results:0.9.9'
     compile project(":slatekit-common")
     compile project(":slatekit-query")
     compile project(":slatekit-meta")

--- a/src/lib/kotlin/slatekit-integration/src/main/kotlin/slatekit/integration/common/AppEntContext.kt
+++ b/src/lib/kotlin/slatekit-integration/src/main/kotlin/slatekit/integration/common/AppEntContext.kt
@@ -30,6 +30,7 @@ import slatekit.common.log.LogsDefault
 import slatekit.common.naming.Namer
 import slatekit.core.common.AppContext
 import slatekit.entities.core.Entities
+import slatekit.results.StatusCodes
 
 /**
   *
@@ -72,9 +73,9 @@ data class AppEntContext(
 
     companion object {
 
-        fun help(): AppEntContext = err(HELP.code)
+        fun help(): AppEntContext = err(StatusCodes.HELP.code)
 
-        fun exit(): AppEntContext = err(EXIT.code)
+        fun exit(): AppEntContext = err(StatusCodes.EXIT.code)
 
 
 

--- a/src/lib/kotlin/slatekit-meta/build.gradle
+++ b/src/lib/kotlin/slatekit-meta/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compile "com.googlecode.json-simple:json-simple:1.1"
-    compile 'com.slatekit:slatekit-results:0.9.8'
+    compile 'com.slatekit:slatekit-results:0.9.9'
     compile project(":slatekit-common")
     compile project(":slatekit-query")
 }

--- a/src/lib/kotlin/slatekit-providers/build.gradle
+++ b/src/lib/kotlin/slatekit-providers/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    compile 'com.slatekit:slatekit-results:0.9.8'
+    compile 'com.slatekit:slatekit-results:0.9.9'
     compile project(":slatekit-common")
     compile project(":slatekit-meta")
     compile project(":slatekit-entities")

--- a/src/lib/kotlin/slatekit-query/build.gradle
+++ b/src/lib/kotlin/slatekit-query/build.gradle
@@ -25,6 +25,6 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 	compile fileTree(dir: 'lib', include: '*.jar')
-    compile 'com.slatekit:slatekit-results:0.9.8'
+    compile 'com.slatekit:slatekit-results:0.9.9'
     compile project(":slatekit-common")
 }

--- a/src/lib/kotlin/slatekit-server/build.gradle
+++ b/src/lib/kotlin/slatekit-server/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     compile "io.ktor:ktor-server-netty:$ktor_version"
     compile "io.ktor:ktor-metrics:$ktor_version"
     compile 'com.sparkjava:spark-core:2.6.0'
-    compile 'com.slatekit:slatekit-results:0.9.8'
+    compile 'com.slatekit:slatekit-results:0.9.9'
 	compile fileTree(dir: 'lib', include: '*.jar')
     compile project(":slatekit-common")
     compile project(":slatekit-meta")

--- a/src/lib/kotlin/slatekit-tests/build.gradle
+++ b/src/lib/kotlin/slatekit-tests/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     compile "mysql:mysql-connector-java:5.1.13"
     //compile "postgresql:postgresql:42.1.1"
     compile "postgresql:postgresql:9.1-901-1.jdbc4"
-    compile 'com.slatekit:slatekit-results:0.9.8'
+    compile 'com.slatekit:slatekit-results:0.9.9'
     compile project(":slatekit-common")
     compile project(":slatekit-app")
     compile project(":slatekit-db")

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/app/AppMetaTests.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/app/AppMetaTests.kt
@@ -17,23 +17,24 @@ import slatekit.common.*
 import slatekit.common.info.About
 import slatekit.app.App
 import slatekit.app.AppRunner
+import slatekit.results.StatusCodes
 
 
 class AppMetaTests  {
 
 
   @Test fun can_request_help() {
-    checkHelp(arrayOf("help", "-help", "--help", "/help", "?"), HELP.code, "help")
+    checkHelp(arrayOf("help", "-help", "--help", "/help", "?"), StatusCodes.HELP.code, "help")
   }
 
 
   @Test fun can_request_about() {
-    checkHelp(arrayOf("about", "-about", "--about", "/about", "info"), ABOUT.code, "help")
+    checkHelp(arrayOf("about", "-about", "--about", "/about", "info"), StatusCodes.ABOUT.code, "help")
   }
 
 
   @Test fun can_request_version() {
-    checkHelp(arrayOf("version", "-version", "--version", "/version", "ver"), VERSION.code,  "help")
+    checkHelp(arrayOf("version", "-version", "--version", "/version", "ver"), StatusCodes.VERSION.code,  "help")
   }
 
 

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/core/ShellTests.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/core/ShellTests.kt
@@ -15,7 +15,6 @@ import org.junit.Test
 import slatekit.apis.core.Annotated
 import slatekit.apis.core.Api
 import slatekit.apis.svcs.Authenticator
-import slatekit.common.HELP
 import slatekit.common.info.ApiKey
 import slatekit.common.info.Credentials
 import slatekit.common.args.Args
@@ -24,6 +23,7 @@ import slatekit.integration.apis.InfoApi
 import slatekit.integration.apis.CliApi
 import slatekit.integration.apis.VersionApi
 import slatekit.integration.common.AppEntContext
+import slatekit.results.StatusCodes
 import slatekit.results.getOrElse
 
 
@@ -48,7 +48,7 @@ class ShellTests  {
       val shell = getCli()
       val result = shell.onCommandExecute("?")
       assert( result.getOrElse { null } == null )
-      assert( result.code == HELP.code )
+      assert( result.code == StatusCodes.HELP.code )
       assert( result.msg  == "help")
     }
 
@@ -57,7 +57,7 @@ class ShellTests  {
       val shell = getCli()
       val result = shell.onCommandExecute("app ?")
       assert( result.getOrElse { null } == null )
-      assert( result.code == HELP.code )
+      assert( result.code == StatusCodes.HELP.code )
       assert( result.msg  == "area ?")
     }
 
@@ -66,7 +66,7 @@ class ShellTests  {
       val shell = getCli()
       val result = shell.onCommandExecute("app.info ?")
       assert( result.getOrElse { null } == null )
-      assert( result.code == HELP.code )
+      assert( result.code == StatusCodes.HELP.code )
       assert(result.msg == "area.api ?")
     }
 
@@ -75,7 +75,7 @@ class ShellTests  {
       val shell = getCli()
       val result = shell.onCommandExecute("app.version.host ?")
       assert( result.getOrElse { null } == null )
-      assert( result.code == HELP.code )
+      assert( result.code == StatusCodes.HELP.code )
       assert( result.msg  == "area.api.action ?")
     }
   

--- a/src/lib/kotlin/slatekit-workers/build.gradle
+++ b/src/lib/kotlin/slatekit-workers/build.gradle
@@ -24,6 +24,6 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    compile 'com.slatekit:slatekit-results:0.9.8'
+    compile 'com.slatekit:slatekit-results:0.9.9'
     compile project(":slatekit-common")
 }


### PR DESCRIPTION
## Overview
bumped slatekit.results to version 0.9.9

## Changes
- removed code from ResultsExt which was moved to the main slatekit.results component.
