### PR TITLE
ADD : DateTime as ThreetenBP

### DIFF
--- a/src/lib/kotlin/slatekit-apis/build.gradle
+++ b/src/lib/kotlin/slatekit-apis/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compile "com.googlecode.json-simple:json-simple:1.1"
     compile 'com.slatekit:slatekit-results:0.9.9'
+    compile 'org.threeten:threetenbp:1.3.8'
     compile project(":slatekit-common")
     compile project(":slatekit-meta")
 }

--- a/src/lib/kotlin/slatekit-apis/src/main/kotlin/slatekit/apis/core/Meta.kt
+++ b/src/lib/kotlin/slatekit-apis/src/main/kotlin/slatekit/apis/core/Meta.kt
@@ -4,7 +4,8 @@ import org.json.simple.JSONObject
 import slatekit.apis.support.JsonSupport
 import slatekit.common.*
 import slatekit.common.encrypt.Encryptor
-import java.time.*
+//import java.time.*
+import org.threeten.bp.*
 
 /**
  * Used to represent a request that originates from a json file.

--- a/src/lib/kotlin/slatekit-apis/src/main/kotlin/slatekit/apis/core/Params.kt
+++ b/src/lib/kotlin/slatekit-apis/src/main/kotlin/slatekit/apis/core/Params.kt
@@ -17,7 +17,8 @@ import org.json.simple.JSONObject
 import slatekit.apis.support.JsonSupport
 import slatekit.common.*
 import slatekit.common.encrypt.Encryptor
-import java.time.*
+//import java.time.*
+import org.threeten.bp.*
 
 /**
  * Used to represent a request that originate from a json file.

--- a/src/lib/kotlin/slatekit-app/build.gradle
+++ b/src/lib/kotlin/slatekit-app/build.gradle
@@ -38,5 +38,6 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 	compile fileTree(dir: 'lib', include: '*.jar')
     compile 'com.slatekit:slatekit-results:0.9.9'
+    compile 'org.threeten:threetenbp:1.3.8'
     compile project(":slatekit-common")
 }

--- a/src/lib/kotlin/slatekit-cloud/build.gradle
+++ b/src/lib/kotlin/slatekit-cloud/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     compile "com.amazonaws:aws-java-sdk-s3:1.11.100"
     compile "com.amazonaws:aws-java-sdk-sqs:1.11.100"
     compile 'com.slatekit:slatekit-results:0.9.9'
+    compile 'org.threeten:threetenbp:1.3.8'
     compile project(":slatekit-common")
     compile project(":slatekit-entities")
     compile project(":slatekit-core")

--- a/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/Conversions.kt
+++ b/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/Conversions.kt
@@ -14,7 +14,8 @@
 package slatekit.common
 
 import slatekit.common.content.Doc
-import java.time.*
+//import java.time.*
+import org.threeten.bp.*
 
 /**
  * Conversions from text to types

--- a/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/DateTime.kt
+++ b/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/DateTime.kt
@@ -13,8 +13,10 @@
 
 package slatekit.common
 
-import java.time.*
-import java.time.format.DateTimeFormatter
+//import java.time.*
+import org.threeten.bp.*
+import org.threeten.bp.format.DateTimeFormatter
+//import java.time.format.DateTimeFormatter
 import java.util.*
 
 /**
@@ -283,7 +285,9 @@ data class DateTime(val raw: ZonedDateTime) {
 
         @JvmStatic
         fun build(date: Date, zone: ZoneId): ZonedDateTime {
-            val dateTime = ZonedDateTime.ofInstant(date.toInstant(), zone)
+            //val dateTime = ZonedDateTime.ofInstant(date.toInstant(), zone)
+            val local = LocalDateTime.of(date.year, date.month, date.date, date.hours, date.minutes, date.seconds, 0)
+            val dateTime = ZonedDateTime.ofInstant(local.toInstant(ZoneOffset.MIN), zone)
             return dateTime
         }
 

--- a/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/DateTime.kt
+++ b/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/DateTime.kt
@@ -19,6 +19,7 @@ import org.threeten.bp.format.DateTimeFormatter
 //import java.time.format.DateTimeFormatter
 import java.util.*
 
+
 /**
  * DateTime wraps a ZonedDateTime, making using the
  * new Java 8 date/time/zones a bit simpler & concise,
@@ -286,8 +287,17 @@ data class DateTime(val raw: ZonedDateTime) {
         @JvmStatic
         fun build(date: Date, zone: ZoneId): ZonedDateTime {
             //val dateTime = ZonedDateTime.ofInstant(date.toInstant(), zone)
-            val local = LocalDateTime.of(date.year, date.month, date.date, date.hours, date.minutes, date.seconds, 0)
-            val dateTime = ZonedDateTime.ofInstant(local.toInstant(ZoneOffset.MIN), zone)
+            //val date = Instant.ofEpochMilli(date.toInstant().toEpochMilli()))
+            val d = java.util.Date()
+            val calendar = java.util.GregorianCalendar()
+            calendar.time = date
+            val year = calendar.get(Calendar.YEAR)
+            val month = calendar.get(Calendar.MONTH) + 1
+            val day = calendar.get(Calendar.DAY_OF_MONTH)
+            val hour = calendar.get(Calendar.HOUR_OF_DAY)
+            val min = calendar.get(Calendar.MINUTE)
+            val sec = calendar.get(Calendar.SECOND)
+            val dateTime = ZonedDateTime.of(year, month, day, hour, min, sec, 0, zone)
             return dateTime
         }
 

--- a/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/Inputs.kt
+++ b/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/Inputs.kt
@@ -14,7 +14,8 @@
 package slatekit.common
 
 import slatekit.common.ids.UniqueId
-import java.time.*
+//import java.time.*
+import org.threeten.bp.*
 import java.util.*
 
 interface InputsUpdateable {

--- a/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/Record.kt
+++ b/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/Record.kt
@@ -14,7 +14,8 @@
 package slatekit.common
 
 import slatekit.common.ids.UniqueId
-import java.time.*
+//import java.time.*
+import org.threeten.bp.*
 
 interface Record : Inputs {
 

--- a/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/Types.kt
+++ b/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/Types.kt
@@ -18,7 +18,8 @@ import slatekit.common.encrypt.EncDouble
 import slatekit.common.encrypt.EncInt
 import slatekit.common.encrypt.EncLong
 import slatekit.common.encrypt.EncString
-import java.time.*
+//import java.time.*
+import org.threeten.bp.*
 
 object Types {
 

--- a/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/args/Args.kt
+++ b/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/args/Args.kt
@@ -15,7 +15,8 @@ package slatekit.common.args
 
 import slatekit.common.*
 import slatekit.results.Try
-import java.time.*
+//import java.time.*
+import org.threeten.bp.*
 
 /**
  * Container for parsed command line arguments that are either named or positional.

--- a/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/conf/Config.kt
+++ b/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/conf/Config.kt
@@ -15,7 +15,8 @@ package slatekit.common.conf
 
 import slatekit.common.*
 import slatekit.common.encrypt.Encryptor
-import java.time.*
+//import java.time.*
+import org.threeten.bp.*
 import java.util.*
 
 /**

--- a/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/conf/ConfigMulti.kt
+++ b/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/conf/ConfigMulti.kt
@@ -17,7 +17,8 @@ import slatekit.common.Conversions
 import slatekit.common.DateTime
 import slatekit.common.Strings
 import slatekit.common.encrypt.Encryptor
-import java.time.*
+//import java.time.*
+import org.threeten.bp.*
 import java.util.*
 
 /**

--- a/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/ext/IntExtensions.kt
+++ b/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/ext/IntExtensions.kt
@@ -1,8 +1,8 @@
 package slatekit.common.ext
 
-import java.time.Duration
-import java.time.Period
-import java.time.temporal.ChronoUnit
+//import java.time.*
+import org.threeten.bp.*
+import org.threeten.bp.temporal.*
 
 val Int.years: Period get() = Period.ofYears(this)
 val Int.months: Period get() = Period.ofMonths(this)

--- a/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/info/Status.kt
+++ b/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/info/Status.kt
@@ -14,7 +14,8 @@
 package slatekit.common.info
 
 import slatekit.common.DateTime
-import java.time.Duration
+//import java.time.*
+import org.threeten.bp.*
 
 data class Status(
     val started: DateTime = DateTime.now(),

--- a/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/metrics/Metric.kt
+++ b/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/metrics/Metric.kt
@@ -1,7 +1,8 @@
 package slatekit.common.metrics
 
 import slatekit.common.DateTime
-import java.time.Instant
+//import java.time.*
+import org.threeten.bp.*
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
 

--- a/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/requests/InputArgs.kt
+++ b/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/requests/InputArgs.kt
@@ -14,7 +14,8 @@
 package slatekit.common.requests
 
 import slatekit.common.*
-import java.time.*
+//import java.time.*
+import org.threeten.bp.*
 
 /**
  * Created by kishorereddy on 5/25/17.

--- a/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/serialization/Serializer.kt
+++ b/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/serialization/Serializer.kt
@@ -16,8 +16,10 @@ package slatekit.common.serialization
 import slatekit.common.DateTime
 import slatekit.results.Result
 import slatekit.results.getOrElse
-import java.time.*
-import java.time.format.DateTimeFormatter
+//import java.time.*
+import org.threeten.bp.*
+import org.threeten.bp.format.*
+//import java.time.format.DateTimeFormatter
 
 /**
  * Created by kishorereddy on 6/14/17.

--- a/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/utils/RecordMap.kt
+++ b/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/utils/RecordMap.kt
@@ -16,7 +16,8 @@ package slatekit.common.utils
 import slatekit.common.DateTime
 import slatekit.common.Record
 import slatekit.common.ids.UniqueId
-import java.time.*
+//import java.time.*
+import org.threeten.bp.*
 import java.util.*
 
 class RecordMap(private val rs: ListMap<String, Any>) : Record {
@@ -38,11 +39,11 @@ class RecordMap(private val rs: ListMap<String, Any>) : Record {
     override fun getDouble(key: String): Double = rs.get(key) as Double
     override fun getUUID(key: String): java.util.UUID = rs.get(key) as UUID
     override fun getUniqueId(key: String): UniqueId = rs.get(key) as UniqueId
-    override fun getInstant(key: String): Instant = (rs.get(key) as java.sql.Timestamp).toInstant()
+    override fun getInstant(key: String): Instant = DateTime.of(rs.get(key) as java.sql.Timestamp).raw.toInstant()
     override fun getDateTime(key: String): DateTime = (rs.get(key) as java.sql.Timestamp).let { DateTime.of(it) }
-    override fun getLocalDate(key: String): LocalDate = (rs.get(key) as java.sql.Date).toLocalDate()
-    override fun getLocalTime(key: String): LocalTime = (rs.get(key) as java.sql.Time).toLocalTime()
-    override fun getLocalDateTime(key: String): LocalDateTime = (rs.get(key) as java.sql.Timestamp).toLocalDateTime()
-    override fun getZonedDateTime(key: String): ZonedDateTime = (rs.get(key) as java.sql.Timestamp).toLocalDateTime().atZone(ZoneId.systemDefault())
+    override fun getLocalDate(key: String): LocalDate = DateTime.of(rs.get(key) as java.sql.Date).date()
+    override fun getLocalTime(key: String): LocalTime = DateTime.of(rs.get(key) as java.sql.Time).time()
+    override fun getLocalDateTime(key: String): LocalDateTime = DateTime.of(rs.get(key) as java.sql.Timestamp).local()
+    override fun getZonedDateTime(key: String): ZonedDateTime = DateTime.of(rs.get(key) as java.sql.Timestamp).atZone(ZoneId.systemDefault()).raw
     override fun getZonedDateTimeUtc(key: String): ZonedDateTime = DateTime.build((rs.get(key) as java.sql.Timestamp), DateTime.UTC)
 }

--- a/src/lib/kotlin/slatekit-core/build.gradle
+++ b/src/lib/kotlin/slatekit-core/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compile 'com.slatekit:slatekit-results:0.9.9'
+    compile 'org.threeten:threetenbp:1.3.8'
     compile project(":slatekit-common")
     compile project(":slatekit-meta")
 }

--- a/src/lib/kotlin/slatekit-core/src/main/kotlin/slatekit/core/gate/Gate.kt
+++ b/src/lib/kotlin/slatekit-core/src/main/kotlin/slatekit/core/gate/Gate.kt
@@ -5,7 +5,8 @@ import slatekit.results.Failure
 import slatekit.results.Result
 import slatekit.results.StatusCodes
 import slatekit.results.Success
-import java.time.temporal.ChronoUnit
+//import java.time.temporal.ChronoUnit
+import org.threeten.bp.temporal.ChronoUnit
 import java.util.*
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference

--- a/src/lib/kotlin/slatekit-core/src/main/kotlin/slatekit/core/scheduler/Scheduler.kt
+++ b/src/lib/kotlin/slatekit-core/src/main/kotlin/slatekit/core/scheduler/Scheduler.kt
@@ -8,7 +8,8 @@ import slatekit.core.scheduler.core.ErrorMode
 import slatekit.core.scheduler.core.RunMode
 import slatekit.common.Status
 import slatekit.results.*
-import java.time.Duration
+//import java.time.Duration
+import org.threeten.bp.Duration
 import java.util.*
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService

--- a/src/lib/kotlin/slatekit-db/build.gradle
+++ b/src/lib/kotlin/slatekit-db/build.gradle
@@ -29,5 +29,6 @@ dependencies {
     compile "com.amazonaws:aws-java-sdk-s3:1.11.100"
     compile "com.amazonaws:aws-java-sdk-sqs:1.11.100"
     compile 'com.slatekit:slatekit-results:0.9.9'
+    compile 'org.threeten:threetenbp:1.3.8'
     compile project(":slatekit-common")
 }

--- a/src/lib/kotlin/slatekit-db/src/main/kotlin/slatekit/db/Db.kt
+++ b/src/lib/kotlin/slatekit-db/src/main/kotlin/slatekit/db/Db.kt
@@ -25,9 +25,8 @@ import java.sql.Connection
 import java.sql.PreparedStatement
 import java.sql.ResultSet
 import java.sql.Statement
-import java.time.LocalDate
-import java.time.LocalDateTime
-import java.time.LocalTime
+//import java.time.*
+import org.threeten.bp.*
 
 /**
  * Light-weight database wrapper.

--- a/src/lib/kotlin/slatekit-db/src/main/kotlin/slatekit/db/DbUtils.kt
+++ b/src/lib/kotlin/slatekit-db/src/main/kotlin/slatekit/db/DbUtils.kt
@@ -16,7 +16,8 @@ import slatekit.common.Types
 import slatekit.common.db.DbCon
 import java.math.BigDecimal
 import java.sql.*
-import java.time.*
+//import java.time.*
+import org.threeten.bp.*
 
 object DbUtils {
 
@@ -129,12 +130,12 @@ object DbUtils {
                 Types.JFloatAnyClass -> stmt.setFloat(pos, arg as Float)
                 Types.JDoubleAnyClass -> stmt.setDouble(pos, arg as Double)
                 //Types.JDecimalClass -> stmt.setBigDecimal(pos, arg as BigDecimal)
-                Types.JLocalDateAnyClass -> stmt.setDate(pos, java.sql.Date.valueOf(arg as LocalDate))
-                Types.JLocalTimeAnyClass -> stmt.setTime(pos, java.sql.Time.valueOf(arg as LocalTime))
-                Types.JLocalDateTimeAnyClass -> stmt.setTimestamp(pos, java.sql.Timestamp.valueOf(arg as LocalDateTime))
-                Types.JZonedDateTimeAnyClass -> stmt.setTimestamp(pos, java.sql.Timestamp.valueOf((arg as ZonedDateTime).toLocalDateTime()))
-                Types.JInstantAnyClass -> stmt.setTimestamp(pos, java.sql.Timestamp.valueOf(LocalDateTime.ofInstant(arg as Instant, ZoneId.systemDefault())))
-                Types.JDateTimeAnyClass -> stmt.setTimestamp(pos, java.sql.Timestamp.valueOf((arg as DateTime).local()))
+                Types.JLocalDateAnyClass -> stmt.setDate(pos, java.sql.Date.valueOf((arg as LocalDate).toJava8LocalDate()))
+                Types.JLocalTimeAnyClass -> stmt.setTime(pos, java.sql.Time.valueOf((arg as LocalTime).toJava8LocalTime()))
+                Types.JLocalDateTimeAnyClass -> stmt.setTimestamp(pos, java.sql.Timestamp.valueOf((arg as LocalDateTime).toJava8LocalDateTime()))
+                Types.JZonedDateTimeAnyClass -> stmt.setTimestamp(pos, java.sql.Timestamp.valueOf(((arg as ZonedDateTime).toJava8ZonedDateTime()).toLocalDateTime()))
+                Types.JInstantAnyClass -> stmt.setTimestamp(pos, java.sql.Timestamp.valueOf((LocalDateTime.ofInstant(arg as Instant, ZoneId.systemDefault()).toJava8LocalDateTime())))
+                Types.JDateTimeAnyClass -> stmt.setTimestamp(pos, java.sql.Timestamp.valueOf(((arg as DateTime).local()).toJava8LocalDateTime()))
             }
         }
     }
@@ -183,4 +184,31 @@ object DbUtils {
             else {
                 text.trim().filter { c -> c.isDigit() || c.isLetter() || c == '_' }
             }
+
+
+    fun org.threeten.bp.LocalDate.toJava8LocalDate():java.time.LocalDate {
+        return java.time.LocalDate.of(this.year, this.month.value, this.dayOfMonth)
+    }
+
+
+    fun org.threeten.bp.LocalTime.toJava8LocalTime():java.time.LocalTime {
+        return java.time.LocalTime.of(this.hour, this.minute, this.second, this.nano)
+    }
+
+
+    fun org.threeten.bp.LocalDateTime.toJava8LocalDateTime():java.time.LocalDateTime {
+        return java.time.LocalDateTime.of(this.year, this.month.value, this.dayOfMonth,
+            this.hour, this.minute, this.second, this.nano)
+    }
+
+
+    fun org.threeten.bp.ZonedDateTime.toJava8ZonedDateTime():java.time.ZonedDateTime {
+        return java.time.ZonedDateTime.of(this.year, this.month.value, this.dayOfMonth,
+            this.hour, this.minute, this.second, this.nano, java.time.ZoneId.of(this.zone.id))
+    }
+
+
+    fun org.threeten.bp.Instant.toJava8Instant():java.time.Instant {
+        return java.time.Instant.ofEpochMilli(this.toEpochMilli())
+    }
 }

--- a/src/lib/kotlin/slatekit-db/src/main/kotlin/slatekit/db/RecordSet.kt
+++ b/src/lib/kotlin/slatekit-db/src/main/kotlin/slatekit/db/RecordSet.kt
@@ -16,7 +16,8 @@ package slatekit.db
 import slatekit.common.DateTime
 import slatekit.common.Record
 import java.sql.ResultSet
-import java.time.*
+//import java.time.*
+import org.threeten.bp.*
 
 class RecordSet(private val rs: ResultSet) : Record {
 
@@ -36,14 +37,13 @@ class RecordSet(private val rs: ResultSet) : Record {
     override fun getLong(key: String): Long = rs.getLong(key)
     override fun getFloat(key: String): Float = rs.getFloat(key)
     override fun getDouble(key: String): Double = rs.getDouble(key)
-    override fun getInstant(key: String): Instant = rs.getTimestamp(key).toInstant()
+    override fun getInstant(key: String): Instant = DateTime.of(rs.getTimestamp(key)).raw.toInstant()
     override fun getDateTime(key: String): DateTime = rs.getTimestamp(key).let { DateTime.of(it) }
-    override fun getLocalDate(key: String): LocalDate = rs.getDate(key).toLocalDate()
-    override fun getLocalTime(key: String): LocalTime = rs.getTime(key).toLocalTime()
-    override fun getLocalDateTime(key: String): LocalDateTime = rs.getTimestamp(key).toLocalDateTime()
-    override fun getZonedDateTime(key: String): ZonedDateTime = rs.getTimestamp(key).toLocalDateTime().atZone(ZoneId.systemDefault())
+    override fun getLocalDate(key: String): LocalDate = DateTime.of(rs.getDate(key)).date()
+    override fun getLocalTime(key: String): LocalTime = DateTime.of(rs.getTime(key)).time()
+    override fun getLocalDateTime(key: String): LocalDateTime = DateTime.of(rs.getTimestamp(key)).local()
+    override fun getZonedDateTime(key: String): ZonedDateTime = DateTime.of(rs.getTimestamp(key)).atZone(ZoneId.systemDefault()).raw
     override fun getZonedDateTimeUtc(key: String): ZonedDateTime = DateTime.build(rs.getTimestamp(key), DateTime.UTC)
-
 
     // Helpers
     override fun <T> getOrNull(key: String, fetcher: (String) -> T): T? {

--- a/src/lib/kotlin/slatekit-entities/build.gradle
+++ b/src/lib/kotlin/slatekit-entities/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compile 'com.slatekit:slatekit-results:0.9.9'
+    compile 'org.threeten:threetenbp:1.3.8'
     compile project(":slatekit-common")
     compile project(":slatekit-meta")
     compile project(":slatekit-db")

--- a/src/lib/kotlin/slatekit-entities/src/main/kotlin/consts.kt
+++ b/src/lib/kotlin/slatekit-entities/src/main/kotlin/consts.kt
@@ -16,7 +16,8 @@ mantra: Simplicity above all else
 
 package slatekit.entities
 
-import java.time.format.DateTimeFormatter
+//import java.time.format.DateTimeFormatter
+import org.threeten.bp.format.*
 
 object Consts {
 

--- a/src/lib/kotlin/slatekit-entities/src/main/kotlin/slatekit/entities/core/EntityMapper.kt
+++ b/src/lib/kotlin/slatekit-entities/src/main/kotlin/slatekit/entities/core/EntityMapper.kt
@@ -28,7 +28,9 @@ import slatekit.meta.Reflector
 import slatekit.meta.models.Model
 import slatekit.meta.models.ModelField
 import slatekit.meta.models.ModelMapper
-import java.time.*
+//import java.time.*
+import org.threeten.bp.*
+
 /**
  * Maps an entity to sql and from sql records.
  *

--- a/src/lib/kotlin/slatekit-entities/src/main/kotlin/slatekit/entities/databases/converters/DateTimeConverter.kt
+++ b/src/lib/kotlin/slatekit-entities/src/main/kotlin/slatekit/entities/databases/converters/DateTimeConverter.kt
@@ -4,7 +4,8 @@ import slatekit.common.DateTime
 import slatekit.entities.databases.SqlConverter
 import slatekit.common.Record
 import slatekit.entities.Consts
-import java.time.format.DateTimeFormatter
+//import java.time.format.DateTimeFormatter
+import org.threeten.bp.format.*
 
 object DateTimeConverter : SqlConverter<DateTime> {
     private val dateTimeFormat: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")

--- a/src/lib/kotlin/slatekit-entities/src/main/kotlin/slatekit/entities/databases/converters/InstantConverter.kt
+++ b/src/lib/kotlin/slatekit-entities/src/main/kotlin/slatekit/entities/databases/converters/InstantConverter.kt
@@ -3,9 +3,8 @@ package slatekit.entities.databases.converters
 import slatekit.entities.databases.SqlConverter
 import slatekit.common.Record
 import slatekit.entities.Consts
-import java.time.Instant
-import java.time.LocalDateTime
-import java.time.ZoneId
+//import java.time.*
+import org.threeten.bp.*
 
 object InstantConverter : SqlConverter<Instant> {
 

--- a/src/lib/kotlin/slatekit-entities/src/main/kotlin/slatekit/entities/databases/converters/LocalDateConverter.kt
+++ b/src/lib/kotlin/slatekit-entities/src/main/kotlin/slatekit/entities/databases/converters/LocalDateConverter.kt
@@ -3,7 +3,8 @@ package slatekit.entities.databases.converters
 import slatekit.entities.databases.SqlConverter
 import slatekit.common.Record
 import slatekit.entities.Consts
-import java.time.LocalDate
+//import java.time.*
+import org.threeten.bp.*
 
 object LocalDateConverter : SqlConverter<LocalDate> {
 

--- a/src/lib/kotlin/slatekit-entities/src/main/kotlin/slatekit/entities/databases/converters/LocalDateTimeConverter.kt
+++ b/src/lib/kotlin/slatekit-entities/src/main/kotlin/slatekit/entities/databases/converters/LocalDateTimeConverter.kt
@@ -4,7 +4,8 @@ import slatekit.common.DateTime
 import slatekit.entities.databases.SqlConverter
 import slatekit.common.Record
 import slatekit.entities.Consts
-import java.time.LocalDateTime
+//import java.time.*
+import org.threeten.bp.*
 
 object LocalDateTimeConverter : SqlConverter<LocalDateTime> {
 

--- a/src/lib/kotlin/slatekit-entities/src/main/kotlin/slatekit/entities/databases/converters/LocalTimeConverter.kt
+++ b/src/lib/kotlin/slatekit-entities/src/main/kotlin/slatekit/entities/databases/converters/LocalTimeConverter.kt
@@ -3,7 +3,8 @@ package slatekit.entities.databases.converters
 import slatekit.entities.databases.SqlConverter
 import slatekit.common.Record
 import slatekit.entities.Consts
-import java.time.LocalTime
+//import java.time.*
+import org.threeten.bp.*
 
 object LocalTimeConverter : SqlConverter<LocalTime> {
 

--- a/src/lib/kotlin/slatekit-entities/src/main/kotlin/slatekit/entities/databases/converters/ZonedDateTimeConverter.kt
+++ b/src/lib/kotlin/slatekit-entities/src/main/kotlin/slatekit/entities/databases/converters/ZonedDateTimeConverter.kt
@@ -4,7 +4,8 @@ import slatekit.common.DateTime
 import slatekit.entities.databases.SqlConverter
 import slatekit.common.Record
 import slatekit.entities.Consts
-import java.time.ZonedDateTime
+//import java.time.*
+import org.threeten.bp.*
 
 object ZonedDateTimeConverter : SqlConverter<ZonedDateTime> {
 

--- a/src/lib/kotlin/slatekit-integration/build.gradle
+++ b/src/lib/kotlin/slatekit-integration/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compile "com.googlecode.json-simple:json-simple:1.1"
     compile 'com.slatekit:slatekit-results:0.9.9'
+    compile 'org.threeten:threetenbp:1.3.8'
     compile project(":slatekit-common")
     compile project(":slatekit-query")
     compile project(":slatekit-meta")

--- a/src/lib/kotlin/slatekit-meta/build.gradle
+++ b/src/lib/kotlin/slatekit-meta/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compile "com.googlecode.json-simple:json-simple:1.1"
     compile 'com.slatekit:slatekit-results:0.9.9'
+    compile 'org.threeten:threetenbp:1.3.8'
     compile project(":slatekit-common")
     compile project(":slatekit-query")
 }

--- a/src/lib/kotlin/slatekit-meta/src/main/kotlin/slatekit/meta/KTypes.kt
+++ b/src/lib/kotlin/slatekit-meta/src/main/kotlin/slatekit/meta/KTypes.kt
@@ -8,7 +8,8 @@ import slatekit.common.encrypt.EncString
 import slatekit.common.ids.UniqueId
 import slatekit.common.content.Content
 import slatekit.common.content.Doc
-import java.time.*
+//import java.time.*
+import org.threeten.bp.*
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
 import kotlin.reflect.full.createType

--- a/src/lib/kotlin/slatekit-meta/src/main/kotlin/slatekit/meta/models/Model.kt
+++ b/src/lib/kotlin/slatekit-meta/src/main/kotlin/slatekit/meta/models/Model.kt
@@ -17,9 +17,8 @@ import slatekit.common.DateTime
 import slatekit.common.naming.Namer
 import slatekit.common.nonEmptyOrDefault
 import slatekit.meta.KTypes
-import java.time.LocalDate
-import java.time.LocalDateTime
-import java.time.LocalTime
+//import java.time.*
+import org.threeten.bp.*
 import kotlin.reflect.KClass
 import kotlin.reflect.KProperty
 import kotlin.reflect.KType

--- a/src/lib/kotlin/slatekit-providers/build.gradle
+++ b/src/lib/kotlin/slatekit-providers/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compile 'com.slatekit:slatekit-results:0.9.9'
+    compile 'org.threeten:threetenbp:1.3.8'
     compile project(":slatekit-common")
     compile project(":slatekit-meta")
     compile project(":slatekit-entities")

--- a/src/lib/kotlin/slatekit-providers/build.gradle
+++ b/src/lib/kotlin/slatekit-providers/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     compile group: 'org.logback-extensions', name: 'logback-ext-loggly'   , version: '0.1.2'
 
     // https://mvnrepository.com/artifact/io.dropwizard.metrics/metrics-core
-    compile group: 'io.dropwizard.metrics', name: 'metrics-core', version: '3.1.0'
+    //compile group: 'io.dropwizard.metrics', name: 'metrics-core', version: '3.1.0'
     compile 'io.micrometer:micrometer-registry-datadog:latest.release'
 
 

--- a/src/lib/kotlin/slatekit-providers/src/main/kotlin/slatekit/providers/metrics/DDConfig.kt
+++ b/src/lib/kotlin/slatekit-providers/src/main/kotlin/slatekit/providers/metrics/DDConfig.kt
@@ -1,8 +1,8 @@
 package slatekit.providers.metrics
 
 import io.micrometer.datadog.DatadogConfig
-//import java.time.*
-import org.threeten.bp.*
+import java.time.*
+//import org.threeten.bp.Duration
 
 /**
  * Configuration class for datadog

--- a/src/lib/kotlin/slatekit-providers/src/main/kotlin/slatekit/providers/metrics/DDConfig.kt
+++ b/src/lib/kotlin/slatekit-providers/src/main/kotlin/slatekit/providers/metrics/DDConfig.kt
@@ -1,7 +1,8 @@
 package slatekit.providers.metrics
 
 import io.micrometer.datadog.DatadogConfig
-import java.time.Duration
+//import java.time.*
+import org.threeten.bp.*
 
 /**
  * Configuration class for datadog

--- a/src/lib/kotlin/slatekit-query/build.gradle
+++ b/src/lib/kotlin/slatekit-query/build.gradle
@@ -26,5 +26,6 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 	compile fileTree(dir: 'lib', include: '*.jar')
     compile 'com.slatekit:slatekit-results:0.9.9'
+    compile 'org.threeten:threetenbp:1.3.8'
     compile project(":slatekit-common")
 }

--- a/src/lib/kotlin/slatekit-server/build.gradle
+++ b/src/lib/kotlin/slatekit-server/build.gradle
@@ -45,6 +45,7 @@ dependencies {
     compile "io.ktor:ktor-metrics:$ktor_version"
     compile 'com.sparkjava:spark-core:2.6.0'
     compile 'com.slatekit:slatekit-results:0.9.9'
+    compile 'org.threeten:threetenbp:1.3.8'
 	compile fileTree(dir: 'lib', include: '*.jar')
     compile project(":slatekit-common")
     compile project(":slatekit-meta")

--- a/src/lib/kotlin/slatekit-server/src/main/kotlin/slatekit/server/ktor/KtorHeaders.kt
+++ b/src/lib/kotlin/slatekit-server/src/main/kotlin/slatekit/server/ktor/KtorHeaders.kt
@@ -20,7 +20,8 @@ import slatekit.common.encrypt.Encryptor
 import io.ktor.request.*
 import slatekit.common.Metadata
 import slatekit.common.Strings
-import java.time.*
+//import java.time.*
+import org.threeten.bp.*
 
 data class KtorHeaders(val req: ApplicationRequest, val enc: Encryptor?) : Metadata {
 

--- a/src/lib/kotlin/slatekit-server/src/main/kotlin/slatekit/server/ktor/KtorParams.kt
+++ b/src/lib/kotlin/slatekit-server/src/main/kotlin/slatekit/server/ktor/KtorParams.kt
@@ -19,7 +19,8 @@ import org.json.simple.JSONObject
 import slatekit.apis.support.JsonSupport
 import slatekit.common.*
 import slatekit.common.encrypt.Encryptor
-import java.time.*
+//import java.time.*
+import org.threeten.bp.*
 
 /**
  * @param req : The raw request

--- a/src/lib/kotlin/slatekit-server/src/main/kotlin/slatekit/server/spark/SparkHeaaders.kt
+++ b/src/lib/kotlin/slatekit-server/src/main/kotlin/slatekit/server/spark/SparkHeaaders.kt
@@ -19,7 +19,8 @@ import slatekit.common.Metadata
 import slatekit.common.Strings
 import slatekit.common.encrypt.Encryptor
 import spark.Request
-import java.time.*
+//import java.time.*
+import org.threeten.bp.*
 
 data class SparkHeaaders(val req: Request, val enc: Encryptor?) : Metadata {
 

--- a/src/lib/kotlin/slatekit-server/src/main/kotlin/slatekit/server/spark/SparkParams.kt
+++ b/src/lib/kotlin/slatekit-server/src/main/kotlin/slatekit/server/spark/SparkParams.kt
@@ -18,7 +18,8 @@ import slatekit.apis.support.JsonSupport
 import slatekit.common.*
 import slatekit.common.encrypt.Encryptor
 import spark.Request
-import java.time.*
+//import java.time.*
+import org.threeten.bp.*
 
 /**
  * @param req : The raw request

--- a/src/lib/kotlin/slatekit-tests/build.gradle
+++ b/src/lib/kotlin/slatekit-tests/build.gradle
@@ -43,6 +43,7 @@ dependencies {
     //compile "postgresql:postgresql:42.1.1"
     compile "postgresql:postgresql:9.1-901-1.jdbc4"
     compile 'com.slatekit:slatekit-results:0.9.9'
+    compile 'org.threeten:threetenbp:1.3.8'
     compile project(":slatekit-common")
     compile project(":slatekit-app")
     compile project(":slatekit-db")

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/common/DateTimeTests.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/common/DateTimeTests.kt
@@ -20,9 +20,8 @@ import org.junit.Assert
 import org.junit.Test
 import slatekit.common.DateTime
 import slatekit.common.ext.*
-import java.time.LocalDateTime
-import java.time.ZoneId
-import java.time.ZonedDateTime
+//import java.time.*
+import org.threeten.bp.*
 
 
 class DateTimeTests {

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/common/DeserializerTests.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/common/DeserializerTests.kt
@@ -12,9 +12,8 @@ import slatekit.common.encrypt.EncLong
 import slatekit.common.encrypt.EncString
 import slatekit.meta.Deserializer
 import test.setup.Movie
-import java.time.LocalDate
-import java.time.LocalDateTime
-import java.time.LocalTime
+//import java.time.*
+import org.threeten.bp.*
 import test.setup.MyEncryptor
 import test.setup.StatusEnum
 import java.util.*

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/entities/Entity_Database_Tests.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/entities/Entity_Database_Tests.kt
@@ -13,7 +13,8 @@ package test.entities
 
 import org.junit.Assert
 import org.junit.Test
-import java.time.*
+//import java.time.*
+import org.threeten.bp.*
 import slatekit.common.Field
 import slatekit.common.ids.UniqueId
 import slatekit.common.conf.ConfFuncs

--- a/src/lib/kotlin/slatekit-workers/build.gradle
+++ b/src/lib/kotlin/slatekit-workers/build.gradle
@@ -25,5 +25,6 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compile 'com.slatekit:slatekit-results:0.9.9'
+    compile 'org.threeten:threetenbp:1.3.8'
     compile project(":slatekit-common")
 }


### PR DESCRIPTION
## Overview
Moved to DateTime library ThreeTenBP to allow for slatekit to be used in Android.

## Ticket(s) 
n/a

## Links(s) 
https://github.com/ThreeTen/threetenbp

## Dependencies
https://github.com/ThreeTen/threetenbp

## Design
There are 3 DateTime libraries available to choose from ( Java 8, Joda, ThreetenBP )
1. Java 8 DateTime is currently ( temporarily ) avoided since it can not be used on Android devices earlier than API 26. And thus slatekit.common and many other libraries also can not be used.
2. Joda was avoided since the libraries / classes are less similar to Java 8 compared to ThreetenBP

## Notes
The switch from Java 8 to/from three ten is reasonably straightforward and involves mostly removing 
```java
// import java.util.time.*
import org.threeten.bp.*
```

## Pending
1. The **DateTime** component may be better suited as a typealias for ZonedDateTime to indicate it coming from slatekit.common. 
2. Existing custom instance methods can be converted to extension methods
3. Existing class methods ( static ones like DateTime.today() ) can be moved to a DateTimes class perhaps

## Tests
- Updated tests as needed 
