### PR TITLE
FIX : CLI output and slatekit bootstrapping of services

### DIFF
--- a/src/lib/kotlin/slatekit-cli/build.gradle
+++ b/src/lib/kotlin/slatekit-cli/build.gradle
@@ -80,9 +80,11 @@ dependencies {
     // /* <slatekit_local>
     if( slatekitSetupViaMaven ) {
         compile "com.slatekit:slatekit-common:$slatekit_version"
+        compile "com.slatekit:slatekit-meta:$slatekit_version"
     } else {
         // */
         compile project(":slatekit-common")
+        compile project(":slatekit-meta")
     } //</slatekit_local>
 }
 

--- a/src/lib/kotlin/slatekit-cli/src/main/kotlin/slatekit/cli/CliIO.kt
+++ b/src/lib/kotlin/slatekit-cli/src/main/kotlin/slatekit/cli/CliIO.kt
@@ -21,6 +21,7 @@ import slatekit.common.serialization.Serializer
 import slatekit.common.serialization.SerializerCsv
 import slatekit.common.serialization.SerializerJson
 import slatekit.common.serialization.SerializerProps
+import slatekit.meta.Serialization
 import slatekit.results.Failure
 import slatekit.results.Success
 import slatekit.results.Try
@@ -43,9 +44,9 @@ open class CliIO(private val io: IO<CliOutput, Unit>) : SemanticWrites {
     /**
      * Different types of serializers
      */
-    private val serializerCsv  by lazy { SerializerCsv(this::serialize, true) }
-    private val serializerJson by lazy { SerializerJson(this::serialize, true) }
-    private val serializerProp by lazy { SerializerProps(false, this::serialize, true) }
+    //private val serializerCsv  by lazy { SerializerCsv(this::serialize, true) }
+    //private val serializerJson by lazy { SerializerJson(this::serialize, true) }
+    //private val serializerProp by lazy { SerializerProps(false, this::serialize, true) }
 
 
     /**
@@ -93,13 +94,13 @@ open class CliIO(private val io: IO<CliOutput, Unit>) : SemanticWrites {
      * @param obj
      */
     private fun write(request:CliRequest, cmd: CliResponse<*>, obj: Any?, outputDir: String) {
-        val format = request.args.getStringOrElse(SysParam.Format.id, "props")
+        val format = request.args.getStringOrElse(SysParam.Format.id, "prop")
         text("===============================")
         val text = when (format) {
-            "csv" -> serializerCsv.serialize(obj)
-            "json" -> serializerJson.serialize(obj)
-            "prop" -> serializerProp.serialize(obj)
-            else -> serializerProp.serialize(obj)
+            "csv"  -> Serialization.csv().serialize(obj)
+            "json" -> Serialization.json().serialize(obj)
+            "prop" -> Serialization.props().serialize(obj)
+            else   -> Serialization.props().serialize(obj)
         }
         text(text)
         text("===============================")

--- a/src/lib/kotlin/slatekit-integration/src/main/kotlin/slatekit/integration/apis/CliApi.kt
+++ b/src/lib/kotlin/slatekit-integration/src/main/kotlin/slatekit/integration/apis/CliApi.kt
@@ -45,11 +45,11 @@ import slatekit.results.Try
  *  3. code gen : generates client code for apis : $codegen=true -lang="kotlin"
  */
 class CliApi(
-        private val creds: Credentials,
         val ctx: slatekit.common.Context,
         val auth: slatekit.apis.core.Auth,
         settings: CliSettings = CliSettings(),
-        apiItems: List<Api> = listOf()
+        apiItems: List<Api> = listOf(),
+        val metaTransform: ((Map<String,Any>) -> List<Pair<String,String>>)? = null
         //val cliMeta: CliMeta? = null
 )
     // TODO: get rid of the "!!" its left over from early days
@@ -85,8 +85,9 @@ class CliApi(
         }
         else {
             // Supply the api-key into each command.
-            val metaWithKey = request.meta.toMap().plus(metaNameForApiKey to creds.key)
-            val metaUpdated = InputArgs(metaWithKey)
+            val existingMeta = request.meta.toMap()
+            val transformedMeta = metaTransform?.invoke(existingMeta)?.toMap() ?: existingMeta
+            val metaUpdated = InputArgs(transformedMeta)
             val requestWithMeta = request.copy(meta = metaUpdated)
             val response = apis.call(requestWithMeta)
             val cliResponse = CliResponse(

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/core/ShellTests.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/core/ShellTests.kt
@@ -111,7 +111,9 @@ class ShellTests  {
 
     // 3. Build up the cli services that handles all the command line features.
     // And setup the api container to hold all the apis.
-    val cli = CliApi(creds, ctx.toAppContext(), Authenticator(apiKeys), apiItems = apis)
+    val cli = CliApi(ctx.toAppContext(), Authenticator(apiKeys), apiItems = apis) { meta ->
+      listOf("api-key" to creds.key)
+    }
     return cli
   }
 }

--- a/src/lib/kotlin/slatekit/build.gradle
+++ b/src/lib/kotlin/slatekit/build.gradle
@@ -76,6 +76,7 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+    compile "mysql:mysql-connector-java:5.1.13"
     compile 'com.squareup.okhttp3:okhttp:3.9.0'
     compile "com.slatekit:slatekit-results:0.9.9"
     compile 'org.threeten:threetenbp:1.3.8'

--- a/src/lib/kotlin/slatekit/src/main/kotlin/slatekit/SlateKitServices.kt
+++ b/src/lib/kotlin/slatekit/src/main/kotlin/slatekit/SlateKitServices.kt
@@ -2,17 +2,24 @@ package slatekit
 
 import slatekit.cloud.aws.AwsCloudFiles
 import slatekit.cloud.aws.AwsCloudQueue
-import slatekit.common.Context
+import slatekit.common.queues.QueueStringConverter
 import slatekit.core.cloud.CloudFiles
 import slatekit.core.cloud.CloudQueue
 import slatekit.core.email.EmailService
 import slatekit.core.email.EmailServiceSendGrid
 import slatekit.core.sms.SmsService
 import slatekit.core.sms.SmsServiceTwilio
+import slatekit.integration.apis.ModuleApi
+import slatekit.integration.common.AppEntContext
+import slatekit.integration.mods.Mod
+import slatekit.integration.mods.ModService
+import slatekit.integration.mods.ModuleContext
+import slatekit.orm.migrations.MigrationService
+import slatekit.orm.migrations.MigrationSettings
 
 interface SlateKitServices {
 
-    val ctx:Context
+    val ctx: AppEntContext
 
 
     fun emails():EmailService {
@@ -39,6 +46,22 @@ interface SlateKitServices {
     fun queues():CloudQueue<String> {
         val apiLogin = ctx.cfg.apiLogin("queues")
         val queue = apiLogin.tag
-        return AwsCloudQueue(queue, apiLogin, 3)
+        return AwsCloudQueue(queue, apiLogin, QueueStringConverter(), 3)
+    }
+
+
+    fun migrations():MigrationService {
+        // entity migration services ( to install/uninstall )
+        val migrationSettings = MigrationSettings(enableLogging = true, enableOutput = true)
+        val migrationService = MigrationService(ctx.ent, ctx.ent.dbs, migrationSettings, ctx.dirs)
+        return migrationService
+    }
+
+
+    fun moduleContext():ModuleContext {
+        // Services/depenencies for all modules
+        val moduleService = ctx.ent.getSvc<Long, Mod>(Mod::class) as ModService
+        val moduleContext = ModuleContext(moduleService, migrations())
+        return moduleContext
     }
 }

--- a/src/lib/kotlin/slatekit/src/main/kotlin/slatekit/info/Dependency.kt
+++ b/src/lib/kotlin/slatekit/src/main/kotlin/slatekit/info/Dependency.kt
@@ -1,0 +1,62 @@
+package slatekit.info
+
+import slatekit.common.DateTime
+import slatekit.common.Field
+import slatekit.common.Random
+import slatekit.entities.core.EntityUpdatable
+import slatekit.entities.core.EntityWithId
+
+
+data class Dependency(
+        @property:Field()
+        override val id: Long = 0L,
+
+        @property:Field(required = true, length = 30)
+        val name:String = "",
+
+        @property:Field(required = true, length = 30)
+        val display:String = "",
+
+        @property:Field(required = true, length = 200)
+        val desc:String = "",
+
+        @property:Field(required = true)
+        val isActive:Boolean = false,
+
+        @property:Field(required = true, length = 12)
+        val version:String = "",
+
+        @property:Field(required = true, length = 30)
+        val namespace:String = "",
+
+        @property:Field(required = true, length = 30)
+        val jarfile:String = "",
+
+        @property:Field(required = true, length = 30)
+        val dependsOn:String = "",
+
+        @property:Field(required = true)
+        val createdAt: DateTime = DateTime.now(),
+
+        @property:Field(required = true)
+        val createdBy: Long = 0,
+
+        @property:Field(required = true)
+        val updatedAt: DateTime = DateTime.now(),
+
+        @property:Field(required = true)
+        val updatedBy: Long = 0
+
+) : EntityWithId<Long>, EntityUpdatable<Long, Dependency> {
+
+    override fun isPersisted(): Boolean = id > 0
+
+    /**
+     * sets the id on the entity and returns the entity with updated id.
+     * @param id
+     * @return
+     */
+    override fun withId(id:Long): Dependency {
+        return this.copy(id = id)
+    }
+}

--- a/src/lib/kotlin/slatekit/src/main/kotlin/slatekit/info/DependencyApi.kt
+++ b/src/lib/kotlin/slatekit/src/main/kotlin/slatekit/info/DependencyApi.kt
@@ -1,0 +1,22 @@
+package slatekit.info
+
+import slatekit.apis.Api
+import slatekit.apis.ApiAction
+import slatekit.apis.security.AuthModes
+import slatekit.apis.security.Protocols
+import slatekit.apis.security.Verbs
+import slatekit.integration.common.ApiBaseEntity
+import slatekit.integration.common.AppEntContext
+import slatekit.results.Outcome
+
+
+@Api(area = "slate", name = "components", desc= "new project setup",
+        auth = AuthModes.apiKey, roles = "*", verb = Verbs.auto, protocol = Protocols.cli)
+class DependencyApi(context: AppEntContext)
+    : ApiBaseEntity<Long, Dependency, DependencyService>(context, Long::class, Dependency::class) {
+
+    @ApiAction(desc= "generates the defaults/seed data")
+    fun seed(): Outcome<List<String>>{
+        return service.seed()
+    }
+}

--- a/src/lib/kotlin/slatekit/src/main/kotlin/slatekit/info/DependencyModule.kt
+++ b/src/lib/kotlin/slatekit/src/main/kotlin/slatekit/info/DependencyModule.kt
@@ -1,0 +1,67 @@
+package slatekit.info
+
+import slatekit.apis.core.Annotated
+import slatekit.apis.core.Api
+import slatekit.apis.support.ApiModule
+import slatekit.common.db.DbType
+import slatekit.integration.common.AppEntContext
+import slatekit.integration.mods.Module
+import slatekit.integration.mods.ModuleContext
+import slatekit.integration.mods.ModuleInfo
+import slatekit.orm.core.orm
+
+class DependencyModule(
+        val appEntCtx: AppEntContext,
+        modCtx: ModuleContext
+) : Module(appEntCtx.toAppContext(), modCtx), ApiModule {
+
+    override val info = ModuleInfo(
+            name = "slatekit.info.dependency",
+            desc = "Sample Entity",
+            version = "1.0",
+            isInstalled = false,
+            isEnabled = true,
+            isDbDependent = true,
+            totalModels = 1,
+            source = Dependency::class.qualifiedName ?: "",
+            dependencies = "none",
+            models = listOf(
+                    Dependency::class.qualifiedName ?: ""
+            )
+    )
+
+
+    /**
+     * hook to initialize
+     */
+    override fun init() {
+
+    }
+
+
+    /**
+     * Handles registration of the module.
+     * In this case, registers the Dependency entity/service with the ORM
+     */
+    override fun register() {
+
+    }
+
+
+    /**
+     * Gets all the apis associated with this module
+     */
+    override fun getApis(): List<Api> {
+        return listOf()
+        //return listOf( (Api(DependencyApi(appEntCtx), declaredOnly = false, setup = Annotated)))
+    }
+
+
+    /**
+     * Used to seed any initial data
+     */
+    override fun seed() {
+        val dependencyService = appEntCtx.ent.getSvc<Long, Dependency>(Dependency::class) as DependencyService
+        dependencyService.seed()
+    }
+}

--- a/src/lib/kotlin/slatekit/src/main/kotlin/slatekit/info/DependencyService.kt
+++ b/src/lib/kotlin/slatekit/src/main/kotlin/slatekit/info/DependencyService.kt
@@ -1,0 +1,29 @@
+package slatekit.info
+
+import slatekit.entities.core.Entities
+import slatekit.entities.core.EntityRepo
+import slatekit.entities.core.EntityService
+import slatekit.results.Outcome
+import slatekit.results.Success
+
+class DependencyService(entities: Entities, repo:EntityRepo<Long, Dependency>)
+    : EntityService<Long, Dependency>(entities, repo) {
+
+
+    fun seed():Outcome<List<String>>{
+        val version = "0.9.15"
+        val items = listOf(
+                Dependency(0L, "slatekit-results", "slatekit-results", "Model successes and failures with optional status codes"  , true, version, "slatekit.results", "slatekit-results.jar","slatekit.results"),
+                Dependency(0L, "slatekit-common" , "slatekit-common" , "Common utilities for both client and server side code"    , true, version, "slatekit.common" , "slatekit-common.jar" ,"slatekit.results"),
+                Dependency(0L, "slatekit-app"    , "slatekit-app"    , "Application template with several built-in features"      , true, version, "slatekit.app"    , "slatekit-app.jar"    ,"slatekit.results"),
+                Dependency(0L, "slatekit-cli"    , "slatekit-cli"    , "Command Line Interface template with built-in features"   , true, version, "slatekit.cli"    , "slatekit-cli.jar"    ,"slatekit.results"),
+                Dependency(0L, "slatekit-db"     , "slatekit-db"     , "Database utilities and functional wrappers on JDBC"       , true, version, "slatekit.db"     , "slatekit-db.jar"     ,"slatekit.results"),
+                Dependency(0L, "slatekit-meta"   , "slatekit-meta"   , "Reflection and metadata related utility code"             , true, version, "slatekit.meta"   , "slatekit-meta.jar"   ,"slatekit.results"),
+                Dependency(0L, "slatekit-query"  , "slatekit-query"  , "Query builder to safely build simple/moderate sql queries", true, version, "slatekit.query"  , "slatekit-query.jar"  ,"slatekit.results")
+        )
+        val results = items
+                .map { it.withId( create(it) )}
+                .map { "created : id=${it.id}, name=${it.name}, desc=${it.desc}" }
+        return Success(results)
+    }
+}

--- a/src/lib/kotlin/slatekit/src/main/kotlin/slatekit/run.kt
+++ b/src/lib/kotlin/slatekit/src/main/kotlin/slatekit/run.kt
@@ -2,6 +2,7 @@ package slatekit
 
 
 import slatekit.app.AppRunner
+import slatekit.integration.common.AppEntContext
 import slatekit.providers.logs.logback.LogbackLogs
 
 
@@ -15,6 +16,6 @@ fun main(args: Array<String>) {
             schema = SlateKit.schema,
             enc = SlateKit.encryptor,
             logs = LogbackLogs(),
-            builder = { ctx -> SlateKit(ctx) }
+            builder = { ctx -> SlateKit(AppEntContext.fromContext(ctx)) }
     )
 }

--- a/src/lib/kotlin/slatekit/src/main/resources/env.conf
+++ b/src/lib/kotlin/slatekit/src/main/resources/env.conf
@@ -40,12 +40,10 @@ log.level    = info
 
 
 # DB Settings - defaulted to dev database
-db.enabled  = false
-db.source   = conf
-db.driver   = com.mysql.jdbc.Driver
-db.url      = jdbc:mysql://localhost/test1
-db.user     = root
-db.pswd     = 123456789
+
+# DB Settings
+db = true
+db.location = user://.slatekit/conf/db.conf
 
 
 # All the ApiLogin files should be setup as property files like below
@@ -55,7 +53,6 @@ db.pswd     = 123456789
 # email.pass    = password
 # email.env     = dev
 # email.tag     = extra value
-
 
 # Email
 email = true
@@ -67,10 +64,10 @@ sms = true
 sms.location = user://.slatekit/conf/sms.conf
 
 # File
-files = false
+files = true
 files.location = user://.slatekit/conf/files.conf
 
 
 # Email
-queues = false
+queues = true
 queues.location = user://.slatekit/conf/queues.conf


### PR DESCRIPTION
## Overview
Fixes for CLI output and extensibility

## Ticket(s) 
n/a

## Links(s) 
n/a

## Dependencies
- CLI has dependency on slatekit.meta now

## Design
- CLI IO now printing using the meta project ( for serializer )
- CLI Api now has lambda to support transformation of metadata

## Notes
n/a

## Pending
n/a

## Tests
n/a
