### PR TITLE
FIX : Java Interop and Android integration

### DIFF
--- a/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/db/DbCon.kt
+++ b/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/db/DbCon.kt
@@ -21,7 +21,7 @@ interface DbCon {
 
   companion object {
 
-    val empty = DbConString("", "", "", "")
+    @JvmField val empty = DbConString("", "", "", "")
   }
 }
 

--- a/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/info/ApiKey.kt
+++ b/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/info/ApiKey.kt
@@ -20,10 +20,10 @@ package slatekit.common.info
  * @param rolesLookup : "admin" -> true, "dev" -> true
  */
 data class ApiKey(
-    val name: String,
-    val key: String,
-    val roles: String,
-    val rolesLookup: Map<String, String>
+    @JvmField val name: String,
+    @JvmField val key: String,
+    @JvmField val roles: String,
+    @JvmField val rolesLookup: Map<String, String>
 ) {
 
     constructor(name: String, key: String, roles: String) : this(name, key, roles,

--- a/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/info/ApiLogin.kt
+++ b/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/info/ApiLogin.kt
@@ -23,11 +23,11 @@ package slatekit.common.info
  * @param tag : Optional tag
  */
 data class ApiLogin(
-    val account: String = "",
-    val key: String = "",
-    val pass: String = "",
-    val env: String = "",
-    val tag: String = ""
+    @JvmField val account: String = "",
+    @JvmField val key: String = "",
+    @JvmField val pass: String = "",
+    @JvmField val env: String = "",
+    @JvmField val tag: String = ""
 ) {
 
     companion object {

--- a/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/info/Credentials.kt
+++ b/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/info/Credentials.kt
@@ -14,13 +14,13 @@
 package slatekit.common.info
 
 data class Credentials(
-    val id: String = "",
-    val name: String = "",
-    val email: String = "",
-    val key: String = "",
-    val env: String = "",
-    val region: String = "",
-    val roles: String = ""
+    @JvmField val id: String = "",
+    @JvmField val name: String = "",
+    @JvmField val email: String = "",
+    @JvmField val key: String = "",
+    @JvmField val env: String = "",
+    @JvmField val region: String = "",
+    @JvmField val roles: String = ""
 ) {
     companion object {
         @JvmStatic

--- a/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/info/Info.kt
+++ b/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/info/Info.kt
@@ -14,10 +14,10 @@
 package slatekit.common.info
 
 data class Info(
-    val about: About,
-    val build: Build,
-    val start: StartInfo,
-    val system: Sys
+    @JvmField val about: About,
+    @JvmField val build: Build,
+    @JvmField val start: StartInfo,
+    @JvmField val system: Sys
 ) {
 
 

--- a/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/info/Sys.kt
+++ b/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/info/Sys.kt
@@ -1,8 +1,8 @@
 package slatekit.common.info
 
 data class Sys(
-        val host: Host,
-        val lang: Lang
+        @JvmField val host: Host,
+        @JvmField val lang: Lang
 ) {
 
     companion object {

--- a/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/utils/Export.kt
+++ b/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/utils/Export.kt
@@ -13,13 +13,13 @@ package slatekit.common.utils
  * @param raw    : Raw typed non-serialized data  e.g. List<TodoItem>
  */
 data class Export<out T>(
-    val version : String,
-    val type    : String,
-    val path    : String,
-    val source  : String,
-    val tag     : String,
-    val format  : String,
-    val size    : Int   ,
-    val data    : String,
-    val raw     : T
+    @JvmField val version : String,
+    @JvmField val type    : String,
+    @JvmField val path    : String,
+    @JvmField val source  : String,
+    @JvmField val tag     : String,
+    @JvmField val format  : String,
+    @JvmField val size    : Int   ,
+    @JvmField val data    : String,
+    @JvmField val raw     : T
 )

--- a/src/lib/kotlin/slatekit-entities/src/main/kotlin/slatekit/entities/core/EntityRepo.kt
+++ b/src/lib/kotlin/slatekit-entities/src/main/kotlin/slatekit/entities/core/EntityRepo.kt
@@ -110,6 +110,13 @@ abstract class EntityRepo<TId, T>(
     abstract fun delete(ids: List<TId>): Int
 
     /**
+     * deletes all entities from the data store using the ids
+     * @param ids
+     * @return
+     */
+    abstract fun deleteAll(): Long
+
+    /**
      * deletes the entity in memory
      *
      * @param entity

--- a/src/lib/kotlin/slatekit-entities/src/main/kotlin/slatekit/entities/features/EntityDeletes.kt
+++ b/src/lib/kotlin/slatekit-entities/src/main/kotlin/slatekit/entities/features/EntityDeletes.kt
@@ -30,11 +30,20 @@ interface EntityDeletes<TId, T> : ServiceSupport<TId, T> where TId: kotlin.Compa
     }
 
     /**
+     * deletes the entity by its id
+     * @param id
+     * @return
+     */
+    fun deleteById(id: TId): Boolean {
+        return repoT().delete(id)
+    }
+
+    /**
      * deletes the entities
      *
      * @param entity
      */
-    fun delete(ids: List<TId>): Int {
+    fun deleteByIds(ids: List<TId>): Int {
 
         // Event out one by one
         return if ( this is EntityHooks ) {
@@ -46,12 +55,11 @@ interface EntityDeletes<TId, T> : ServiceSupport<TId, T> where TId: kotlin.Compa
     }
 
     /**
-     * deletes the entity by its id
-     * @param id
+     * deletes all the items in the table
      * @return
      */
-    fun deleteById(id: TId): Boolean {
-        return repoT().delete(id)
+    fun deleteAll(): Long {
+        return repoT().deleteAll()
     }
 
     /**

--- a/src/lib/kotlin/slatekit-entities/src/main/kotlin/slatekit/entities/features/EntityFinds.kt
+++ b/src/lib/kotlin/slatekit-entities/src/main/kotlin/slatekit/entities/features/EntityFinds.kt
@@ -4,6 +4,7 @@ import slatekit.query.IQuery
 import slatekit.query.Query
 import slatekit.entities.core.Entity
 import slatekit.entities.core.ServiceSupport
+import slatekit.query.QueryEncoder
 import kotlin.reflect.KProperty
 
 interface EntityFinds<TId, T> : ServiceSupport<TId, T> where TId: kotlin.Comparable<TId>, T:Entity<TId> {
@@ -15,6 +16,18 @@ interface EntityFinds<TId, T> : ServiceSupport<TId, T> where TId: kotlin.Compara
      */
     fun find(query: IQuery): List<T> {
         return repoT().find(query)
+    }
+
+    /**
+     * finds items based on the field value
+     * @param field: The field name
+     * @param value: The value to check for
+     * @return
+     */
+    fun findByField(field:String, value: Any): List<T> {
+        // Get column name from model schema ( if available )
+        val column = QueryEncoder.ensureField(field)
+        return repoT().findBy(column, "=", value)
     }
 
     /**

--- a/src/lib/kotlin/slatekit-entities/src/main/kotlin/slatekit/entities/repos/EntityRepoInMemory.kt
+++ b/src/lib/kotlin/slatekit-entities/src/main/kotlin/slatekit/entities/repos/EntityRepoInMemory.kt
@@ -141,6 +141,17 @@ open class EntityRepoInMemory<TId, T>(
     }
 
     /**
+     * deletes all entities from the data store using the ids
+     * @param ids
+     * @return
+     */
+    override fun deleteAll(): Long {
+        val count = _items.size
+        _items = ListMap(listOf())
+        return count.toLong()
+    }
+
+    /**
      * gets the entity from memory with the specified id.
      *
      * @param id
@@ -164,7 +175,9 @@ open class EntityRepoInMemory<TId, T>(
      * @return
      */
     override fun findBy(field: String, op: String, value: Any): List<T> {
-        val prop = Reflector.findProperty(entityType, field)
+        val propRaw  = Reflector.findPropertyExtended(entityType, field)
+        //val prop =  if(propRaw != null) propRaw else Reflector.findField(entityType)
+        val prop = propRaw
         val matched = prop?.let { property ->
             val cls = KTypes.getClassFromType(property.returnType)
 

--- a/src/lib/kotlin/slatekit-entities/src/main/kotlin/slatekit/entities/repos/EntityRepoInMemory.kt
+++ b/src/lib/kotlin/slatekit-entities/src/main/kotlin/slatekit/entities/repos/EntityRepoInMemory.kt
@@ -32,9 +32,33 @@ import slatekit.meta.models.Model
 import kotlin.reflect.KClass
 
 
-open class EntityRepoInMemoryWithLongId<T>(cls:KClass<T>)
-    : EntityRepoInMemory<Long, T>(cls, Long::class, EntityMapperInMemory<Long,T>(Model(cls), LongIdGenerator()) )
-        where T:Entity<Long>
+open class EntityRepoInMemoryWithLongId<T>(cls:KClass<T>, idGen:IdGenerator<Long>)
+    : EntityRepoInMemory<Long, T>(cls, Long::class, EntityMapperInMemory<Long,T>(Model(cls), idGen), idGenerator = idGen)
+        where T:Entity<Long> {
+
+    companion object {
+        @JvmStatic operator fun <T> invoke(cls:KClass<T>):EntityRepoInMemoryWithLongId<T> where T:Entity<Long> {
+            val idGen = LongIdGenerator()
+            return EntityRepoInMemoryWithLongId(cls, idGen)
+        }
+    }
+}
+
+
+open class EntityRepoInMemoryWithIntId<T>(cls:KClass<T>, idGen:IdGenerator<Int>)
+    : EntityRepoInMemory<Int, T>(cls, Int::class, EntityMapperInMemory<Int,T>(Model(cls), idGen), idGenerator = idGen )
+        where T:Entity<Int> {
+
+    companion object {
+
+        @JvmStatic operator fun <T> invoke(cls:KClass<T>):EntityRepoInMemoryWithIntId<T> where T:Entity<Int> {
+            val idGen = IntIdGenerator()
+            return EntityRepoInMemoryWithIntId(cls, idGen)
+        }
+    }
+}
+
+
 
 /**
  * An In-Memory repository to store entities.

--- a/src/lib/kotlin/slatekit-entities/src/main/kotlin/slatekit/entities/repos/EntityRepoSql.kt
+++ b/src/lib/kotlin/slatekit-entities/src/main/kotlin/slatekit/entities/repos/EntityRepoSql.kt
@@ -114,6 +114,16 @@ abstract class EntityRepoSql<TId, T>(
     }
 
     /**
+     * deletes all entities from the data store using the ids
+     * @param ids
+     * @return
+     */
+    override fun deleteAll(): Long {
+        val count = db.update("delete from ${repoName()};")
+        return count.toLong()
+    }
+
+    /**
      * deletes items based on the field name and value
      * @param field: The field name
      * @param value: The value to check for

--- a/src/lib/kotlin/slatekit-entities/src/main/kotlin/slatekit/entities/repos/IdGenerator.kt
+++ b/src/lib/kotlin/slatekit-entities/src/main/kotlin/slatekit/entities/repos/IdGenerator.kt
@@ -6,8 +6,16 @@ interface IdGenerator<TId:Comparable<TId>> {
 }
 
 
-
 class LongIdGenerator : IdGenerator<Long>{
     private var id = 0L
     override fun nextId():Long = ++id
+}
+
+
+class IntIdGenerator : IdGenerator<Int>{
+    private var id:Int = 0
+    override fun nextId():Int {
+        val next =  ++id
+        return next
+    }
 }

--- a/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Model.kt
+++ b/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Model.kt
@@ -70,12 +70,12 @@ class Example_Model : Cmd("model") {
 
     // CASE 3: add fields for text, bool, int, date etc.
     model = Model("Resource", "", dataType = User::class, desc = "", tableName = "users", _propList = listOf(
-                 ModelField(name = "key"        , isRequired = true, maxLength = 30, dataCls = String::class, dataTpe = KTypes.KStringType),
-                 ModelField(name = "api"       , isRequired = true, maxLength = 30, dataCls = String::class, dataTpe = KTypes.KStringType),
-                 ModelField(name = "recordState", isRequired = true, dataCls = Int::class, dataTpe = KTypes.KIntType),
-                 ModelField(name = "hostInfo"   , isRequired = true, dataCls = Host::class, dataTpe = Host::class.createType()),
-                 ModelField(name = "created"    , isRequired = true, dataCls = DateTime::class, dataTpe = KTypes.KDateTimeType),
-                 ModelField(name = "updated"    , isRequired = true, dataCls = DateTime::class, dataTpe = KTypes.KDateTimeType)
+                 ModelField(name = "key"        , isRequired = true, maxLength = 30, dataCls = String::class),
+                 ModelField(name = "api"       , isRequired = true, maxLength = 30, dataCls = String::class),
+                 ModelField(name = "recordState", isRequired = true, dataCls = Int::class),
+                 ModelField(name = "hostInfo"   , isRequired = true, dataCls = Host::class),
+                 ModelField(name = "created"    , isRequired = true, dataCls = DateTime::class),
+                 ModelField(name = "updated"    , isRequired = true, dataCls = DateTime::class)
       ))
 
     // CASE 4. check for any fields

--- a/src/lib/kotlin/slatekit-meta/src/main/kotlin/slatekit/meta/Reflector.kt
+++ b/src/lib/kotlin/slatekit-meta/src/main/kotlin/slatekit/meta/Reflector.kt
@@ -189,6 +189,11 @@ object Reflector {
         return item
     }
 
+    fun findPropertyExtended(cls: KClass<*>, name: String): KProperty<*>? {
+        val item = cls.memberProperties.find { it.name == name }
+        return item
+    }
+
     fun getMethod(cls: KClass<*>, name: String): KCallable<*>? {
         val mem = cls.members.find { m -> m.name == name }
         return mem

--- a/src/lib/kotlin/slatekit-meta/src/main/kotlin/slatekit/meta/models/Model.kt
+++ b/src/lib/kotlin/slatekit-meta/src/main/kotlin/slatekit/meta/models/Model.kt
@@ -48,7 +48,7 @@ class Model(
     /**
      * The field that represents the id
      */
-    val idField: ModelField? get() = _propList?.find { p -> p.cat == "id" }
+    val idField: ModelField? get() = _propList?.find { p -> p.category == "id" }
 
     /**
      * The mapping of property names to the fields.
@@ -139,6 +139,38 @@ class Model(
      */
     fun addId(name: String, dataType: KClass<*>, autoIncrement: Boolean = false): Model {
         return addField(null, name, Long::class, dataType.createType(), "", true, 0, 0, name, 0, cat = "id")
+    }
+
+
+    /**
+     * builds a new model by adding an text field to the list of fields
+     * @param name
+     * @param desc
+     * @param isRequired
+     * @param minLength
+     * @param maxLength
+     * @param storedName
+     * @param defaultValue
+     * @param tag
+     * @param cat
+     * @return
+     */
+    fun addString(
+            name: String,
+            desc: String = "",
+            isRequired: Boolean = false,
+            minLength: Int = 0,
+            maxLength: Int = 50,
+            storedName: String? = null,
+            defaultValue: String = "",
+            encrypt: Boolean = false,
+            tag: String = "",
+            cat: String = "data"
+    ): Model {
+        return addField(
+                name, String::class, KTypes.KStringType, desc, isRequired, minLength, maxLength, storedName,
+                defaultValue, encrypt, tag, cat
+        )
     }
 
     /**

--- a/src/lib/kotlin/slatekit-meta/src/main/kotlin/slatekit/meta/models/Model.kt
+++ b/src/lib/kotlin/slatekit-meta/src/main/kotlin/slatekit/meta/models/Model.kt
@@ -115,6 +115,41 @@ class Model(
                 !field.returnType.isMarkedNullable,
                 minLength, maxLength, storedName, defaultValue, encrypt, tag, cat
         )
+    }/**
+     * builds a new model by adding an text field to the list of fields
+     * @param name
+     * @param desc
+     * @param isRequired
+     * @param minLength
+     * @param maxLength
+     * @param storedName
+     * @param defaultValue
+     * @param tag
+     * @param cat
+     * @return
+     */
+    fun add(
+            field: KProperty<*>,
+            required:Boolean,
+            desc: String = "",
+            minLength: Int = 0,
+            maxLength: Int = 50,
+            storedName: String? = null,
+            defaultValue: String = "",
+            encrypt: Boolean = false,
+            tag: String = "",
+            cat: String = "data"
+    ): Model {
+        val fieldType = ModelUtils.fieldType(field)
+        return addField(
+                field,
+                field.name,
+                KTypes.getClassFromType(field.returnType),
+                fieldType,
+                desc,
+                required,
+                minLength, maxLength, storedName, defaultValue, encrypt, tag, cat
+        )
     }
 
     /**

--- a/src/lib/kotlin/slatekit-meta/src/main/kotlin/slatekit/meta/models/ModelField.kt
+++ b/src/lib/kotlin/slatekit-meta/src/main/kotlin/slatekit/meta/models/ModelField.kt
@@ -23,7 +23,7 @@ data class ModelField(
         @JvmField val desc: String = "",
         @JvmField val prop: KProperty<*>? = null,
         @JvmField val dataCls: KClass<*>,
-        @JvmField val dataTpe: KType,
+        @JvmField val dataTpe: ModelFieldType = ModelUtils.fieldType(dataCls),
         @JvmField val storedName: String = "",
         @JvmField val pos: Int = 0,
         @JvmField val isRequired: Boolean = true,
@@ -85,8 +85,8 @@ data class ModelField(
          * @return
          */
         @JvmStatic
-        fun id(name: String, dataType: KClass<*>, dataKType: KType): ModelField {
-            return build(null, name, "", dataType, dataKType, true, true, true, false, 0, 0, name, 0, cat = "id")
+        fun id(name: String, dataType: KClass<*>, dataTpe: ModelFieldType): ModelField {
+            return build(null, name, "", dataType, dataTpe, true, true, true, false, 0, 0, name, 0, cat = "id")
         }
 
         /**
@@ -109,7 +109,7 @@ data class ModelField(
             name: String,
             desc: String = "",
             dataType: KClass<*>,
-            dataKType: KType,
+            dataFieldType: ModelFieldType,
             isRequired: Boolean = false,
             isUnique: Boolean = false,
             isIndexed: Boolean = false,
@@ -131,7 +131,7 @@ data class ModelField(
                     desc = desc,
                     prop = prop,
                     dataCls = dataType,
-                    dataTpe = dataKType,
+                    dataTpe = dataFieldType,
                     isEnum = isEnum,
                     storedName = finalName,
                     pos = 0,

--- a/src/lib/kotlin/slatekit-meta/src/main/kotlin/slatekit/meta/models/ModelField.kt
+++ b/src/lib/kotlin/slatekit-meta/src/main/kotlin/slatekit/meta/models/ModelField.kt
@@ -19,28 +19,29 @@ import slatekit.meta.Reflector
 import kotlin.reflect.*
 
 data class ModelField(
-    val name: String,
-    val desc: String = "",
-    val prop: KProperty<*>? = null,
-    val dataCls: KClass<*>,
-    val dataTpe: KType,
-    val storedName: String = "",
-    val pos: Int = 0,
-    val isRequired: Boolean = true,
-    val minLength: Int = -1,
-    val maxLength: Int = -1,
-    val isEnum: Boolean = false,
-    val isUnique: Boolean = false,
-    val isIndexed: Boolean = false,
-    val isUpdatable: Boolean = true,
-    val defaultVal: Any? = null,
-    val encrypt: Boolean = false,
-    val key: String = "",
-    val extra: String = "",
-    val example: String = "",
-    val tag: String = "",
-    val cat: String = "",
-    val model: Model? = null
+        @JvmField val name: String,
+        @JvmField val desc: String = "",
+        @JvmField val prop: KProperty<*>? = null,
+        @JvmField val dataCls: KClass<*>,
+        @JvmField val dataTpe: KType,
+        @JvmField val storedName: String = "",
+        @JvmField val pos: Int = 0,
+        @JvmField val isRequired: Boolean = true,
+        @JvmField val minLength: Int = -1,
+        @JvmField val maxLength: Int = -1,
+        @JvmField val isEnum: Boolean = false,
+        @JvmField val isUnique: Boolean = false,
+        @JvmField val isIndexed: Boolean = false,
+        @JvmField val isUpdatable: Boolean = true,
+        @JvmField val defaultValue: Any? = null,
+        @JvmField val encrypt: Boolean = false,
+        @JvmField val key: String = "",
+        @JvmField val extra: String = "",
+        @JvmField val example: String = "",
+        @JvmField val format: String = "",
+        @JvmField val tag: String = "",
+        @JvmField val category: String = "",
+        @JvmField val model: Model? = null
 ) {
 
     override fun toString(): String {
@@ -54,13 +55,14 @@ data class ModelField(
         text.append(", isRequired : $isRequired")
         text.append(", minLength : $minLength")
         text.append(", maxLength : $maxLength")
-        text.append(", defaultVal : $defaultVal")
+        text.append(", defaultValue : $defaultValue")
         text.append(", encrypt : $encrypt")
         text.append(", example : $example")
+        text.append(", format : $format")
         text.append(", key : $key")
         text.append(", extra : $extra")
         text.append(", tag : $tag")
-        text.append(", cat : $cat")
+        text.append(", category : $category")
         text.append(" )")
         return text.toString()
     }
@@ -139,11 +141,11 @@ data class ModelField(
                     isUpdatable = isUpdatable,
                     minLength = minLength,
                     maxLength = maxLength,
-                    defaultVal = defaultValue,
+                    defaultValue = defaultValue,
                     encrypt = encrypt,
                     key = "",
                     tag = tag,
-                    cat = cat
+                    category = cat
             )
             return field
         }

--- a/src/lib/kotlin/slatekit-meta/src/main/kotlin/slatekit/meta/models/ModelFieldType.kt
+++ b/src/lib/kotlin/slatekit-meta/src/main/kotlin/slatekit/meta/models/ModelFieldType.kt
@@ -1,0 +1,35 @@
+package slatekit.meta.models
+
+
+sealed class ModelFieldType {
+
+    // Bool
+    object TypeBool    : ModelFieldType()
+
+    // Chars/Strings
+    object TypeChar    : ModelFieldType()
+    object TypeString  : ModelFieldType()
+    object TypeText    : ModelFieldType()
+
+    // Numbers
+    object TypeShort   : ModelFieldType()
+    object TypeInt     : ModelFieldType()
+    object TypeLong    : ModelFieldType()
+    object TypeFloat   : ModelFieldType()
+    object TypeDouble  : ModelFieldType()
+    object TypeDecimal : ModelFieldType()
+
+    // Dates
+    object TypeLocalDate     : ModelFieldType()
+    object TypeLocalTime     : ModelFieldType()
+    object TypeLocalDateTime : ModelFieldType()
+    object TypeZonedDateTime : ModelFieldType()
+    object TypeInstant       : ModelFieldType()
+    object TypeDateTime      : ModelFieldType()
+
+    // Enum
+    object TypeEnum : ModelFieldType()
+
+    // Complex/Object
+    object TypeObject : ModelFieldType()
+}

--- a/src/lib/kotlin/slatekit-meta/src/main/kotlin/slatekit/meta/models/ModelFieldType.kt
+++ b/src/lib/kotlin/slatekit-meta/src/main/kotlin/slatekit/meta/models/ModelFieldType.kt
@@ -4,32 +4,33 @@ package slatekit.meta.models
 sealed class ModelFieldType {
 
     // Bool
-    object TypeBool    : ModelFieldType()
+    object typeBool    : ModelFieldType()
 
     // Chars/Strings
-    object TypeChar    : ModelFieldType()
-    object TypeString  : ModelFieldType()
-    object TypeText    : ModelFieldType()
+    object typeChar    : ModelFieldType()
+    object typeString  : ModelFieldType()
+    object typeText    : ModelFieldType()
 
     // Numbers
-    object TypeShort   : ModelFieldType()
-    object TypeInt     : ModelFieldType()
-    object TypeLong    : ModelFieldType()
-    object TypeFloat   : ModelFieldType()
-    object TypeDouble  : ModelFieldType()
-    object TypeDecimal : ModelFieldType()
+    object typeShort   : ModelFieldType()
+    object typeInt     : ModelFieldType()
+    object typeLong    : ModelFieldType()
+    object typeFloat   : ModelFieldType()
+    object typeDouble  : ModelFieldType()
+    object typeDecimal : ModelFieldType()
 
     // Dates
-    object TypeLocalDate     : ModelFieldType()
-    object TypeLocalTime     : ModelFieldType()
-    object TypeLocalDateTime : ModelFieldType()
-    object TypeZonedDateTime : ModelFieldType()
-    object TypeInstant       : ModelFieldType()
-    object TypeDateTime      : ModelFieldType()
+    object typeLocalDate     : ModelFieldType()
+    object typeLocalTime     : ModelFieldType()
+    object typeLocalDateTime : ModelFieldType()
+    object typeZonedDateTime : ModelFieldType()
+    object typeInstant       : ModelFieldType()
+    object typeDateTime      : ModelFieldType()
 
     // Enum
-    object TypeEnum : ModelFieldType()
+    object typeEnum : ModelFieldType()
+    object typeUUID : ModelFieldType()
 
     // Complex/Object
-    object TypeObject : ModelFieldType()
+    object typeObject : ModelFieldType()
 }

--- a/src/lib/kotlin/slatekit-meta/src/main/kotlin/slatekit/meta/models/ModelMapper.kt
+++ b/src/lib/kotlin/slatekit-meta/src/main/kotlin/slatekit/meta/models/ModelMapper.kt
@@ -134,11 +134,12 @@ open class ModelMapper(
                 val encrypt = anno.encrypt
                 val prop = matchedField.first
                 val fieldKType = matchedField.first.returnType
+                val fieldType = ModelUtils.fieldType(prop)
                 val fieldCls = fieldKType.jvmErasure
                 val modelField = ModelField.build(
                         prop = prop, name = name,
                         dataType = fieldCls,
-                        dataKType = fieldKType,
+                        dataFieldType = fieldType,
                         isRequired = required,
                         isIndexed = anno.indexed,
                         isUnique = anno.unique,

--- a/src/lib/kotlin/slatekit-meta/src/main/kotlin/slatekit/meta/models/ModelType.kt
+++ b/src/lib/kotlin/slatekit-meta/src/main/kotlin/slatekit/meta/models/ModelType.kt
@@ -1,0 +1,8 @@
+package slatekit.meta.models
+
+import kotlin.reflect.KClass
+
+sealed class ModelType {
+    data class ModelJavaType(val cls:Class<*>)
+    data class ModelKotlinType(val cls: KClass<*>)
+}

--- a/src/lib/kotlin/slatekit-meta/src/main/kotlin/slatekit/meta/models/ModelUtils.kt
+++ b/src/lib/kotlin/slatekit-meta/src/main/kotlin/slatekit/meta/models/ModelUtils.kt
@@ -1,0 +1,41 @@
+package slatekit.meta.models
+
+import org.threeten.bp.LocalDate
+import org.threeten.bp.LocalDateTime
+import org.threeten.bp.LocalTime
+import org.threeten.bp.ZonedDateTime
+import slatekit.common.DateTime
+import slatekit.meta.KTypes
+import java.util.*
+import kotlin.reflect.KClass
+import kotlin.reflect.KProperty
+
+object ModelUtils {
+
+    fun fieldType(field:KProperty<*>):ModelFieldType {
+        val fieldCls = KTypes.getClassFromType(field.returnType)
+        return fieldType(fieldCls)
+    }
+
+    fun fieldType(fieldCls:KClass<*>):ModelFieldType {
+        val fieldType = when(fieldCls){
+            Boolean::class -> ModelFieldType.typeBool
+            Char::class -> ModelFieldType.typeChar
+            String::class -> ModelFieldType.typeString
+            Short::class -> ModelFieldType.typeShort
+            Int::class -> ModelFieldType.typeInt
+            Long::class -> ModelFieldType.typeLong
+            Float::class -> ModelFieldType.typeFloat
+            Double::class -> ModelFieldType.typeDouble
+            LocalDate::class -> ModelFieldType.typeLocalDate
+            LocalTime::class -> ModelFieldType.typeLocalTime
+            LocalDateTime::class -> ModelFieldType.typeLocalDateTime
+            ZonedDateTime::class -> ModelFieldType.typeZonedDateTime
+            DateTime::class -> ModelFieldType.typeDateTime
+            Enum::class -> ModelFieldType.typeEnum
+            UUID::class -> ModelFieldType.typeUUID
+            else -> ModelFieldType.typeObject
+        }
+        return fieldType
+    }
+}

--- a/src/lib/kotlin/slatekit-query/src/main/kotlin/slatekit/query/Condition.kt
+++ b/src/lib/kotlin/slatekit-query/src/main/kotlin/slatekit/query/Condition.kt
@@ -13,7 +13,9 @@
 
 package slatekit.query
 
-class Condition(val field: Any, val comparison: String, val fieldValue: Any) : ICondition {
+class Condition(@JvmField val field: Any,
+                @JvmField val comparison: String,
+                @JvmField val fieldValue: Any) : ICondition {
 
     /**
      * string represention of condition

--- a/src/lib/kotlin/slatekit-query/src/main/kotlin/slatekit/query/ConditionGroup.kt
+++ b/src/lib/kotlin/slatekit-query/src/main/kotlin/slatekit/query/ConditionGroup.kt
@@ -13,7 +13,9 @@
 
 package slatekit.query
 
-data class ConditionGroup(val left: Any, val operator: String, val right: Any) : ICondition {
+data class ConditionGroup(@JvmField val left: Any,
+                          @JvmField val operator: String,
+                          @JvmField val right: Any) : ICondition {
 
     override fun toStringQuery(): String = getString(left) + " " + operator + " " + getString(right)
 

--- a/src/lib/kotlin/slatekit-query/src/main/kotlin/slatekit/query/FieldValue.kt
+++ b/src/lib/kotlin/slatekit-query/src/main/kotlin/slatekit/query/FieldValue.kt
@@ -16,4 +16,4 @@ package slatekit.query
 /**
  * Created by kreddy on 12/24/2015.
  */
-data class FieldValue(val field: String, val fieldValue: Any)
+data class FieldValue(@JvmField val field: String, @JvmField val fieldValue: Any)

--- a/src/lib/kotlin/slatekit-query/src/main/kotlin/slatekit/query/IQuery.kt
+++ b/src/lib/kotlin/slatekit-query/src/main/kotlin/slatekit/query/IQuery.kt
@@ -23,6 +23,10 @@ interface IQuery {
 
     fun toFilter(): String
 
+    fun hasOrderBy():Boolean
+
+    fun getOrderBy():String
+
     fun set(field: String, fieldValue: Any?): IQuery
 
     fun set(vararg pairs:Pair<String, Any>): IQuery

--- a/src/lib/kotlin/slatekit-query/src/main/kotlin/slatekit/query/Query.kt
+++ b/src/lib/kotlin/slatekit-query/src/main/kotlin/slatekit/query/Query.kt
@@ -31,6 +31,11 @@ open class Query : IQuery {
     protected val _joins = mutableListOf<Triple<String, String, String>>()
     protected val _orders = mutableListOf<Pair<String, String>>()
 
+
+    override fun hasOrderBy():Boolean = !_orders.isEmpty()
+
+    override fun getOrderBy():String = _orders.joinToString(",") { it.first + it.second }
+
     override fun toUpdates(): List<FieldValue> = _data.updates.toList()
 
     override fun toUpdatesText(): String {

--- a/src/lib/kotlin/slatekit-query/src/main/kotlin/slatekit/query/Query.kt
+++ b/src/lib/kotlin/slatekit-query/src/main/kotlin/slatekit/query/Query.kt
@@ -26,7 +26,6 @@ open class Query : IQuery {
     )
 
     protected val _limit = AtomicInteger(0)
-    protected val EmptyString = "''"
     protected val _data = QueryData(mutableListOf(), mutableListOf())
     protected val _joins = mutableListOf<Triple<String, String, String>>()
     protected val _orders = mutableListOf<Pair<String, String>>()
@@ -249,5 +248,6 @@ open class Query : IQuery {
         @JvmStatic val Null = "null"
         @JvmStatic val Asc = "asc"
         @JvmStatic val Desc = "desc"
+        @JvmStatic val EmptyString = "''"
     }
 }

--- a/src/lib/kotlin/slatekit-query/src/main/kotlin/slatekit/query/QueryEncoder.kt
+++ b/src/lib/kotlin/slatekit-query/src/main/kotlin/slatekit/query/QueryEncoder.kt
@@ -21,6 +21,7 @@ import java.util.*
 
 object QueryEncoder {
 
+    @JvmStatic
     fun convertVal(value: Any?): String {
         return when (value) {
             Query.Null -> "null"
@@ -48,6 +49,7 @@ object QueryEncoder {
      * @param text
      * @return
      */
+    @JvmStatic
     fun ensureValue(text: String): String =
             if (text.isNullOrEmpty()) {
                 ""
@@ -55,6 +57,7 @@ object QueryEncoder {
                 text.replace("'", "''")
             }
 
+    @JvmStatic
     fun ensureField(text: String): String =
             if (text.isNullOrEmpty()) {
                 ""
@@ -69,6 +72,7 @@ object QueryEncoder {
      * @param compare
      * @return
      */
+    @JvmStatic
     fun ensureCompare(compare: String): String =
             when (compare) {
                 "=" -> "="
@@ -83,6 +87,7 @@ object QueryEncoder {
                 else -> ensureField(compare)
             }
 
+    @JvmStatic
     fun toString(value: String): String {
         val s = ensureValue(value)
         val res = if (s.isNullOrEmpty()) "''" else "'$s'"

--- a/src/lib/kotlin/slatekit-query/src/main/kotlin/slatekit/query/QueryTyped.kt
+++ b/src/lib/kotlin/slatekit-query/src/main/kotlin/slatekit/query/QueryTyped.kt
@@ -1,7 +1,5 @@
 package slatekit.query
 
-import slatekit.query.IQuery
-import slatekit.query.Query
 
 fun IQuery.where(field: kotlin.reflect.KProperty<*>, compare: kotlin.String, fieldValue: Any?): IQuery {
     val finalValue = fieldValue ?: Query.Null

--- a/src/lib/kotlin/slatekit-tests/src/test/java/JavaEntityTests.java
+++ b/src/lib/kotlin/slatekit-tests/src/test/java/JavaEntityTests.java
@@ -1,0 +1,73 @@
+
+import app.SimpleEvent;
+import app.SimpleEventService;
+import entities.SqliteDb;
+import kotlin.reflect.KClass;
+import meta.ModelHelpers;
+import org.junit.Assert;
+import org.junit.Test;
+import org.threeten.bp.LocalDateTime;
+import org.threeten.bp.ZoneId;
+import org.threeten.bp.ZonedDateTime;
+import slatekit.common.db.DbCon;
+import slatekit.common.db.DbLookup;
+import slatekit.common.log.LogsDefault;
+import slatekit.entities.core.Entities;
+import slatekit.entities.core.EntityRepo;
+import slatekit.entities.repos.EntityRepoInMemoryWithIntId;
+import slatekit.entities.repos.IdGenerator;
+import slatekit.entities.repos.IntIdGenerator;
+import slatekit.meta.models.Model;
+
+import java.util.List;
+
+public class JavaEntityTests {
+
+    @Test
+    public void can_create_model() {
+        Model model = SimpleEvent.asModel();
+
+        KClass cls = ModelHelpers.model(SimpleEvent.class);
+        Assert.assertTrue(model.getDataType() == cls);
+        Assert.assertEquals(12, model.getFields().size());
+        Assert.assertEquals("title", model.getFields().get(1).name);
+        Assert.assertEquals(true, model.getFields().get(1).isRequired);
+        Assert.assertEquals("details", model.getFields().get(2).name);
+        Assert.assertEquals(false, model.getFields().get(2).isRequired);
+    }
+
+
+    @Test
+    public void can_create_service() {
+        Entities entities = new Entities( (con) -> new SqliteDb(), DbLookup.defaultDb(DbCon.empty), null, LogsDefault.INSTANCE, null);
+        IdGenerator<Integer> idGen = new IntIdGenerator();
+        EntityRepo<Integer, SimpleEvent> repo = new EntityRepoInMemoryWithIntId(ModelHelpers.model(SimpleEvent.class), idGen);
+        SimpleEventService service = new SimpleEventService(entities, repo);
+        List<SimpleEvent> simpleEvents = service.getAll();
+        Assert.assertTrue(simpleEvents.size() == 0);
+    }
+
+
+    @Test
+    public void can_use_repo() {
+        Entities entities = new Entities( (con) -> new SqliteDb(), DbLookup.defaultDb(DbCon.empty), null, LogsDefault.INSTANCE, null);
+        IdGenerator<Integer> idGen = new IntIdGenerator();
+        EntityRepo<Integer, SimpleEvent> repo = new EntityRepoInMemoryWithIntId(ModelHelpers.model(SimpleEvent.class), idGen);
+        SimpleEventService service = new SimpleEventService(entities, repo);
+        List<SimpleEvent> simpleEvents = service.getAll();
+        Assert.assertTrue(simpleEvents.size() == 0);
+
+        LocalDateTime timestamp = LocalDateTime.of(2019, 3, 1, 9, 30, 0);
+        SimpleEvent simpleEvent = new SimpleEvent();
+        simpleEvent.title = "event 1";
+        simpleEvent.details = "details 1";
+        simpleEvent.startTime = ZonedDateTime.of(timestamp, ZoneId.systemDefault());
+        simpleEvent.endTime = ZonedDateTime.of(timestamp.plusHours(1), ZoneId.systemDefault());
+        simpleEvent.url = "www.event1.com";
+
+        int id = service.create(simpleEvent);
+        Assert.assertEquals(id , 1);
+        List<SimpleEvent> all = service.getAll();
+        Assert.assertEquals(1, all.size());
+    }
+}

--- a/src/lib/kotlin/slatekit-tests/src/test/java/JavaEntityTests.java
+++ b/src/lib/kotlin/slatekit-tests/src/test/java/JavaEntityTests.java
@@ -2,6 +2,7 @@
 import app.SimpleEvent;
 import app.SimpleEventService;
 import entities.SqliteDb;
+import kotlin.ranges.IntRange;
 import kotlin.reflect.KClass;
 import meta.ModelHelpers;
 import org.junit.Assert;
@@ -69,5 +70,28 @@ public class JavaEntityTests {
         Assert.assertEquals(id , 1);
         List<SimpleEvent> all = service.getAll();
         Assert.assertEquals(1, all.size());
+    }
+
+
+    @Test
+    public void can_find_by() {
+        Entities entities = new Entities( (con) -> new SqliteDb(), DbLookup.defaultDb(DbCon.empty), null, LogsDefault.INSTANCE, null);
+        IdGenerator<Integer> idGen = new IntIdGenerator();
+        EntityRepo<Integer, SimpleEvent> repo = new EntityRepoInMemoryWithIntId(ModelHelpers.model(SimpleEvent.class), idGen);
+        SimpleEventService service = new SimpleEventService(entities, repo);
+
+        for(int ndx = 1; ndx < 3; ndx++ ) {
+            LocalDateTime timestamp = LocalDateTime.of(2019, 3, 1, 9, 30, 0);
+            SimpleEvent simpleEvent = new SimpleEvent();
+            simpleEvent.title = "event " + ndx ;
+            simpleEvent.details = "details " + ndx;
+            simpleEvent.startTime = ZonedDateTime.of(timestamp, ZoneId.systemDefault());
+            simpleEvent.endTime = ZonedDateTime.of(timestamp.plusHours(1), ZoneId.systemDefault());
+            simpleEvent.url = "www.event" + ndx + ".com";
+            int id = service.create(simpleEvent);
+        }
+
+        List<SimpleEvent> matches = service.findByField("title", "event 1");
+        Assert.assertEquals(1, matches.size());
     }
 }

--- a/src/lib/kotlin/slatekit-tests/src/test/java/app/AppEvent.java
+++ b/src/lib/kotlin/slatekit-tests/src/test/java/app/AppEvent.java
@@ -1,0 +1,97 @@
+package app;
+
+import core.Event;
+import entities.IEntityUnique;
+import org.threeten.bp.ZonedDateTime;
+import slatekit.entities.core.Entity;
+import slatekit.meta.models.Model;
+
+/**
+ * Created by kv on 6/11/2015.
+ */
+public abstract class AppEvent extends Event implements Entity<Integer>, IEntityUnique {
+
+
+    public final String sourceType;
+
+
+    public AppEvent(String type) {
+        sourceType = type;
+        this.spaceId = "none";
+    }
+
+
+    public String spaceId;
+
+
+    protected int _id;
+
+
+    // Audit fields for time/user
+    public String createdBy;
+    public ZonedDateTime createdAt;
+    public String updatedBy;
+    public ZonedDateTime updatedAt;
+
+
+    // Tracking ( also useful during tracking / upgrades / schema changes )
+    public String tag;
+    public String label;
+    public String uuid;
+
+    /**
+     * gets the id
+     *
+     * NOTES:
+     * 1. This is a method instead of a val "id" to allow domain entities more
+     *    flexibility in how to implement their own identity.
+     * 2. This also allows for 2 default implementations ( EntityWithId and EntityWithSetId )
+     *
+     * @return
+     */
+    public Integer identity() {
+        return _id;
+    }
+
+
+    /**
+     * whether or not this entity is persisted.
+     * @return
+     */
+    public boolean isPersisted() {
+        return _id > 0;
+    }
+
+
+    // To conform to interfaces ( IEntity/IEntityUnique )
+    public int getId() {
+        return _id;
+    }
+
+    public void setId(int value) {
+        _id = value;
+    }
+
+
+    @Override
+    public String getUUID() {
+        return uuid;
+    }
+
+
+    @Override
+    public void setUUID(String guid) {
+        uuid = guid;
+    }
+
+
+    /**
+     * Once we have a model schema of the entity,
+     * we can do many things with it, such as standardize the serialization
+     * to any format.
+     *
+     * @return
+     */
+    public abstract Model toModel();
+
+}

--- a/src/lib/kotlin/slatekit-tests/src/test/java/app/AppSchema.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/java/app/AppSchema.kt
@@ -1,0 +1,26 @@
+package app
+
+import app.AppEvent
+import slatekit.meta.models.Model
+
+object AppSchema {
+
+    @JvmStatic
+    fun setupEventMappings(model: Model): Model {
+        val finalModel = model.add(AppEvent::calendarId)
+                .add(AppEvent::title, true)
+                .add(AppEvent::details, false)
+                .add(AppEvent::startTime)
+                .add(AppEvent::endTime)
+                .add(AppEvent::timeZone)
+
+                // Attributes
+                .add(AppEvent::status)
+                .add(AppEvent::icon)
+                .add(AppEvent::value)
+                .add(AppEvent::priority)
+                .add(AppEvent::isFavorite)
+                .add(AppEvent::isEnabled)
+        return finalModel
+    }
+}

--- a/src/lib/kotlin/slatekit-tests/src/test/java/app/ISimpleEventService.java
+++ b/src/lib/kotlin/slatekit-tests/src/test/java/app/ISimpleEventService.java
@@ -1,0 +1,7 @@
+package app;
+
+import slatekit.entities.services.EntityServices;
+
+public interface ISimpleEventService extends EntityServices<Integer, SimpleEvent> {
+
+}

--- a/src/lib/kotlin/slatekit-tests/src/test/java/app/SimpleEvent.java
+++ b/src/lib/kotlin/slatekit-tests/src/test/java/app/SimpleEvent.java
@@ -1,0 +1,28 @@
+package app;
+
+import meta.ModelHelpers;
+import slatekit.entities.core.Entity;
+import slatekit.meta.models.Model;
+
+// Temp to represent a vacation day
+// e.g. date of vacation, total days, and reason
+public class SimpleEvent extends AppEvent implements Entity<Integer> {
+
+    public SimpleEvent() {
+        super("simple-event");
+    }
+
+
+    @Override
+    public Model toModel() {
+        return asModel();
+    }
+
+
+    public static Model asModel() {
+
+        Model model = new Model(ModelHelpers.model(SimpleEvent.class), "");
+        Model finalModel = AppSchema.setupEventMappings(model);
+        return finalModel;
+    }
+}

--- a/src/lib/kotlin/slatekit-tests/src/test/java/app/SimpleEventService.java
+++ b/src/lib/kotlin/slatekit-tests/src/test/java/app/SimpleEventService.java
@@ -1,0 +1,12 @@
+package app;
+
+import slatekit.entities.core.Entities;
+import slatekit.entities.core.EntityRepo;
+import slatekit.entities.core.EntityService;
+
+public class SimpleEventService extends EntityService<Integer, SimpleEvent> implements ISimpleEventService {
+
+    public SimpleEventService(Entities entities, EntityRepo<Integer, SimpleEvent> repo){
+        super(entities, repo);
+    }
+}

--- a/src/lib/kotlin/slatekit-tests/src/test/java/core/Event.java
+++ b/src/lib/kotlin/slatekit-tests/src/test/java/core/Event.java
@@ -1,0 +1,35 @@
+package core;
+
+import org.threeten.bp.ZonedDateTime;
+
+public class Event {
+    // Link to calendar
+    public String calendarId;
+    public long instanceId;
+
+    // Basics
+    public String title;
+    public String details;
+    public ZonedDateTime startTime;
+    public ZonedDateTime endTime;
+    public String timeZone;
+
+    // Contact
+    public String location;
+    public String phone;
+    public String email;
+    public String url;
+    public String website;
+
+    // Status
+    public int status;
+    public boolean isEnabled;
+    public boolean isFavorite;
+
+    // Props ( cost, value, priority )
+    public double cost;
+    public int value;
+    public int priority;
+    public int ordinal;
+    public String icon;
+}

--- a/src/lib/kotlin/slatekit-tests/src/test/java/entities/IEntityUnique.java
+++ b/src/lib/kotlin/slatekit-tests/src/test/java/entities/IEntityUnique.java
@@ -1,0 +1,7 @@
+
+package entities;
+
+public interface IEntityUnique {
+    void setUUID(String guid);
+    String getUUID();
+}

--- a/src/lib/kotlin/slatekit-tests/src/test/java/entities/SqliteDb.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/java/entities/SqliteDb.kt
@@ -1,0 +1,63 @@
+package entities
+
+import slatekit.common.db.IDb
+import slatekit.common.db.Mapper
+import java.sql.ResultSet
+
+class SqliteDb : IDb {
+    override val onError: (Exception) -> Unit
+        get() = TODO("not implemented") //To change initializer of created properties use File | Settings | File Templates.
+
+    override fun open(): IDb {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun execute(sql: String) {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun <T> getScalarOpt(sql: String, typ: Class<*>, inputs: List<Any>?): T? {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun insert(sql: String, inputs: List<Any>?): Long {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun insertGetId(sql: String, inputs: List<Any>?): String {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun update(sql: String, inputs: List<Any>?): Int {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun <T> query(sql: String, callback: (ResultSet) -> T?, moveNext: Boolean, inputs: List<Any>?): T? {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun <T> mapOne(sql: String, mapper: Mapper, inputs: List<Any>?): T? {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun <T> mapMany(sql: String, mapper: Mapper, inputs: List<Any>?): List<T>? {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun <T> callQuery(procName: String, callback: (ResultSet) -> T?, moveNext: Boolean, inputs: List<Any>?): T? {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun <T> callQueryMapped(procName: String, mapper: Mapper, inputs: List<Any>?): List<T>? {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun callUpdate(procName: String, inputs: List<Any>?): Int {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun errorHandler(ex: Exception) {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+}

--- a/src/lib/kotlin/slatekit-tests/src/test/java/meta/ModelHelpers.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/java/meta/ModelHelpers.kt
@@ -1,0 +1,12 @@
+package meta
+
+import kotlin.reflect.KClass
+
+
+object ModelHelpers {
+
+    @JvmStatic
+    fun model(cls:Class<*>):KClass<*> {
+        return cls.kotlin
+    }
+}


### PR DESCRIPTION
## Overview
Misc fixes and improvements to address Java Interop and Android integration.
Also fixes for `meta modeling` for the ORM component

## Ticket(s) 
n/a

## Links(s) 
n/a

## Dependencies
n/a

## Design
- Added **@JvmStatic** where needed
- Added **@JvmField** where needed
- Added missing methods for **Query** component to get order by 
- Improvements for the **Model** component in **slatekit.meta** project
- Renamed methods in the **slatekit.entities.feature** 

## Notes
n/a

## Pending
n/a

## Tests
1. added unit-tests for Java to test integration of the **slatekit.entities** component

