### PR TITLE
ADD : Alert Service ( using slack )

### DIFF
--- a/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/ids/Identity.kt
+++ b/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/ids/Identity.kt
@@ -1,0 +1,25 @@
+package slatekit.common.ids
+
+import java.util.*
+
+interface Identity {
+    val area:String
+    val name:String
+    val uuid:String
+    val fullName:String
+}
+
+
+/**
+ * Simple Identity with just name / uuid.
+ * This is used to identity sources / components such as :
+ * 1. Sender of notifications
+ * 2. Worker for background tasks
+ */
+data class SimpleIdentity(
+        override val area:String,
+        override val name:String,
+        override val uuid:String = UUID.randomUUID().toString()) : Identity {
+
+    override val fullName:String = "$area-$name-$uuid"
+}

--- a/src/lib/kotlin/slatekit-core/src/main/kotlin/slatekit/core/alerts/Alert.kt
+++ b/src/lib/kotlin/slatekit-core/src/main/kotlin/slatekit/core/alerts/Alert.kt
@@ -1,0 +1,39 @@
+package slatekit.core.alerts
+
+/**
+ * @param area   : logical area of an application
+ * @param name   : name of the alert        e.g. "NEW_DEVICE_REGISTRATION"
+ * @param uuid   : unique id ( UUID ) identification
+ * @param desc   : description of the alert e.g. "User registration via mobile"
+ * @param success: whether or not this is a success or failure
+ * @param status : integer code for more specific status
+ * @param target : name / id of the target/destination, should match the @see [AlertTarget.target]
+ * @param tag    : correlation id/tag for linking to other items
+ * @param fields : Optional list of additional fields related to the alert
+ *
+ * event : {
+ *     area: 'app.registration.new',
+ *     name: 'NEW_DEVICE_REGISTRATION',
+ *     uuid: 'abc-123-xyz',
+ *     desc: 'User registration via mobile',
+ *     success: true,
+ *     code: 200,
+ *     target: "registration-alerts",
+ *     tag : "a1b2c3",
+ *     fields: [
+ *         { title: 'region' , value:'usa'     , pii: false },
+ *         { title: 'device' , value:'android', pii: false }
+ *     ]
+ * }}
+ */
+data class Alert(
+                 val area: String,
+                 val name: String,
+                 val uuid: String,
+                 val desc: String,
+                 val success: Boolean,
+                 val status: Int,
+                 val target: String,
+                 val tag: String,
+                 val fields: List<AlertField>?
+)

--- a/src/lib/kotlin/slatekit-core/src/main/kotlin/slatekit/core/alerts/AlertField.kt
+++ b/src/lib/kotlin/slatekit-core/src/main/kotlin/slatekit/core/alerts/AlertField.kt
@@ -1,0 +1,11 @@
+package slatekit.core.alerts
+
+/**
+ * Represents a field that is part of the alert.
+ * @param name : Name of the field e.g. "env"
+ * @param value: Value of the field e.g. "dev"'
+ * @param tags : Optional tags associated w/ the data
+ */
+data class AlertField(val name:String,
+                      val value:Any?,
+                      val tags:List<String>? = null)

--- a/src/lib/kotlin/slatekit-core/src/main/kotlin/slatekit/core/alerts/AlertService.kt
+++ b/src/lib/kotlin/slatekit-core/src/main/kotlin/slatekit/core/alerts/AlertService.kt
@@ -1,8 +1,9 @@
 package slatekit.core.alerts
 
+import slatekit.common.ids.Identity
 import slatekit.core.common.Sender
 
 abstract class AlertService : Sender<Alert> {
-
+    abstract val identity: Identity
     abstract val settings: AlertSettings
 }

--- a/src/lib/kotlin/slatekit-core/src/main/kotlin/slatekit/core/alerts/AlertService.kt
+++ b/src/lib/kotlin/slatekit-core/src/main/kotlin/slatekit/core/alerts/AlertService.kt
@@ -1,0 +1,8 @@
+package slatekit.core.alerts
+
+import slatekit.core.common.Sender
+
+abstract class AlertService : Sender<Alert> {
+
+    abstract val settings: AlertSettings
+}

--- a/src/lib/kotlin/slatekit-core/src/main/kotlin/slatekit/core/alerts/AlertServiceSlack.kt
+++ b/src/lib/kotlin/slatekit-core/src/main/kotlin/slatekit/core/alerts/AlertServiceSlack.kt
@@ -4,6 +4,7 @@ import okhttp3.Request
 import org.json.simple.JSONArray
 import org.json.simple.JSONObject
 import slatekit.common.HttpRPC
+import slatekit.common.ids.Identity
 import slatekit.results.Outcome
 import slatekit.results.Success
 import slatekit.results.builders.Outcomes
@@ -11,7 +12,8 @@ import slatekit.results.builders.Outcomes
 /**
  * @param settings: The list of slack channels
  */
-class AlertServiceSlack(override val settings: AlertSettings) : AlertService() {
+class AlertServiceSlack(override val identity: Identity,
+                        override val settings: AlertSettings) : AlertService() {
 
     private val baseUrl = "https://hooks.slack.com/services"
 

--- a/src/lib/kotlin/slatekit-core/src/main/kotlin/slatekit/core/alerts/AlertServiceSlack.kt
+++ b/src/lib/kotlin/slatekit-core/src/main/kotlin/slatekit/core/alerts/AlertServiceSlack.kt
@@ -1,0 +1,121 @@
+package slatekit.core.alerts
+
+import okhttp3.Request
+import org.json.simple.JSONArray
+import org.json.simple.JSONObject
+import slatekit.common.HttpRPC
+import slatekit.results.Outcome
+import slatekit.results.Success
+import slatekit.results.builders.Outcomes
+
+/**
+ * @param settings: The list of slack channels
+ */
+class AlertServiceSlack(override val settings: AlertSettings) : AlertService() {
+
+    private val baseUrl = "https://hooks.slack.com/services"
+
+    /**
+     * Whether or not sending is enabled
+     */
+    override fun isEnabled(model:Alert):Boolean {
+        val target = this.settings.targets.firstOrNull { it.target == model.target }
+        return target?.enabled ?: false
+    }
+
+
+    /**
+     * Validates the model supplied
+     * @param model: The data model to send ( e.g. EmailMessage )
+     */
+    override fun validate(model: Alert): Outcome<Alert> {
+        val target = this.settings.targets.firstOrNull { it.target == model.target }
+        return when {
+            model.target.isNullOrEmpty() -> Outcomes.invalid("target not provided")
+            model.name.isNullOrEmpty()   -> Outcomes.invalid("name not provided")
+            target == null               -> Outcomes.invalid("target invalid")
+            else -> Outcomes.success(model)
+        }
+    }
+
+
+    /**
+     * Builds the HttpRequest for the model
+     * @param model: The data model to send ( e.g. Alert )
+     */
+    override fun build(model: Alert): Outcome<Request> {
+        // Parameters
+        val target = settings.targets.first { it.target == model.target }
+        val url = "$baseUrl/${target.account}/${target.channel}/${target.key}"
+        val json = build(model, target)
+        val jsonString = json.toString()
+        val request = HttpRPC().build(
+                method = HttpRPC.Method.Post,
+                urlRaw = url,
+                headerParams = mapOf("Content-type" to "application/json"),
+                body  = HttpRPC.Body.JsonContent(jsonString))
+        return Success(request)
+    }
+
+
+    fun build(alert: Alert, target: AlertTarget):JSONObject {
+        // Convert the code to a color
+        // 1. code 0 = pending = yellow
+        // 2. code 1 = success = green
+        // 3. code 2 = failure = red
+        val color = when (alert.status) {
+            1 -> "#2ecc71"
+            2 -> "#e74c3c"
+            else -> "#F0E68C"
+        }
+
+        // Convert all the fields supplied to a slack field definition
+        val json = JSONObject()
+        json.put("channel", "#${target.name}")
+        json.put("username", target.sender)
+        json.put("icon_emoji", ":slack:")
+
+        val attachment = JSONObject()
+        val fields = JSONArray()
+        attachment.put("fallback", alert.name)
+        attachment.put("pretext", alert.desc)
+        attachment.put("color", color)
+        attachment.put("title", alert.name)
+        attachment.put("fields", fields)
+
+        // 1 attachment only
+        val attachments = JSONArray()
+        json.put("attachments", attachments)
+        attachments.add(attachment)
+
+        // Fields
+        alert.fields?.forEach {
+
+            val field = JSONObject()
+            field.put("title", it.name)
+            field.put("value", it.value ?: "")
+            field.put("short", true)
+            fields.add(field)
+        }
+        return json
+    }
+
+
+//    /**
+//     *
+//     * curl -X POST --data-urlencode
+//     * channel : #service1-alerts
+//     * hook    : https://hooks.slack.com/services/T00000000/B00000000/t00000000000000000000000
+//     * payload : { ... }
+//     */
+//    private fun send(target: AlertTarget, json: String):Notice<Boolean> {
+//        val url = "$baseUrl/${target.account}/${target.channel}/${target.key}"
+//        val result = HttpRPC().sendSync(
+//                method = HttpRPC.Method.Post,
+//                url = url,
+//                headers = mapOf("Content-type" to "application/json"),
+//                body = HttpRPC.Body.JsonContent(json)
+//        )
+//        return result.fold({ Success(true) }, { Failure(it.message ?: "") })
+//    }
+}

--- a/src/lib/kotlin/slatekit-core/src/main/kotlin/slatekit/core/alerts/AlertSettings.kt
+++ b/src/lib/kotlin/slatekit-core/src/main/kotlin/slatekit/core/alerts/AlertSettings.kt
@@ -1,0 +1,6 @@
+package slatekit.core.alerts
+
+/**
+ * Settings for Alerts, currently just a list of targets
+ */
+data class AlertSettings(val targets:List<AlertTarget>)

--- a/src/lib/kotlin/slatekit-core/src/main/kotlin/slatekit/core/alerts/AlertTarget.kt
+++ b/src/lib/kotlin/slatekit-core/src/main/kotlin/slatekit/core/alerts/AlertTarget.kt
@@ -1,0 +1,23 @@
+package slatekit.core.alerts
+
+/**
+ * Represents a target/destination for an alert.
+ * E.g Could be a Slack Hook for a channel.
+ *
+ * @param target : Name of this target   e.g. "slack-signup-alerts"
+ * @param channel: Id of the target      e.g. "ABC123"       : slack channel id
+ * @param account: Account of the target e.g. "XYZ123"       : slack account id
+ * @param name   : Name of the target    e.g. "User Alerts"  : slack channel name
+ * @param key    : Api Key of the target e.g. "123456"       : slack api key
+ * @param enabled: Whether or not this is enabled ( can be turned on/off at runtime )
+ *
+ */
+open class AlertTarget(
+        val target: String,
+        val sender: String,
+        val channel: String,
+        val account: String,
+        val name: String,
+        val key: String,
+        var enabled: Boolean
+)

--- a/src/lib/kotlin/slatekit-core/src/main/kotlin/slatekit/core/common/Sender.kt
+++ b/src/lib/kotlin/slatekit-core/src/main/kotlin/slatekit/core/common/Sender.kt
@@ -4,9 +4,15 @@ import okhttp3.Request
 import okhttp3.Response
 import slatekit.common.HttpRPC
 import slatekit.results.Outcome
+import slatekit.results.builders.Outcomes
 import slatekit.results.then
 
 interface Sender<T> {
+
+    /**
+     * Whether or not sending is enabled
+     */
+    fun isEnabled(model:T):Boolean = true
 
     /**
      * Validates the model supplied
@@ -25,7 +31,11 @@ interface Sender<T> {
      * @param model: The data model to send ( e.g. EmailMessage )
      */
     suspend fun send(model: T): Outcome<String> {
-        return build(model).then { send(it) }.map { it.body()?.string() ?: "" }
+        return if(!isEnabled(model)) {
+            Outcomes.ignored("Not enabled")
+        } else {
+            build(model).then { send(it) }.map { it.body()?.string() ?: "" }
+        }
     }
 
     /**
@@ -41,7 +51,11 @@ interface Sender<T> {
      * @param model: The data model to send ( e.g. EmailMessage )
      */
     fun sendSync(model: T): Outcome<String> {
-        return build(model).then { sendSync(it) }.map { it.body()?.string() ?: "" }
+        return if(!isEnabled(model)) {
+            Outcomes.ignored("Not enabled")
+        } else {
+            build(model).then { sendSync(it) }.map { it.body()?.string() ?: "" }
+        }
     }
 
     /**


### PR DESCRIPTION
## Overview
Add support for an Alert Service ( using slack ) as the first default implementation

## Ticket(s) 
n/a

## Links(s) 
https://api.slack.com/incoming-webhooks

## Dependencies
n/a only http calls

## Design
1. Using the same approach as the Email/Sms senders 
2. Data model is Alert 
3. The entire model can be validated, checked for isEnabled, and be converted to an Http request

## Notes
1. the target is the slack channel id.

## Pending
n/a

## Tests
n/a
