### PR TITLE
ADD : Cloud Document DB support via AWS Dynamo

### DIFF
--- a/src/lib/kotlin/slatekit-cloud/build.gradle
+++ b/src/lib/kotlin/slatekit-cloud/build.gradle
@@ -77,6 +77,7 @@ dependencies {
     compile "com.amazonaws:aws-java-sdk-core:1.11.100"
     compile "com.amazonaws:aws-java-sdk-s3:1.11.100"
     compile "com.amazonaws:aws-java-sdk-sqs:1.11.100"
+    compile "com.amazonaws:aws-java-sdk-dynamodb:1.11.100"
     compile 'com.squareup.okhttp3:okhttp:3.9.0'
     compile 'org.threeten:threetenbp:1.3.8'
 

--- a/src/lib/kotlin/slatekit-cloud/src/main/kotlin/slatekit/cloud/aws/AwsCloudDocs.kt
+++ b/src/lib/kotlin/slatekit-cloud/src/main/kotlin/slatekit/cloud/aws/AwsCloudDocs.kt
@@ -1,0 +1,89 @@
+package slatekit.cloud.aws
+
+import com.amazonaws.auth.AWSCredentials
+import com.amazonaws.auth.AWSStaticCredentialsProvider
+import slatekit.core.slatekit.core.cloud.CloudDoc
+import slatekit.core.slatekit.core.cloud.CloudDocs
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder
+import com.amazonaws.services.dynamodbv2.document.DynamoDB
+import com.amazonaws.services.dynamodbv2.document.Item
+import com.amazonaws.services.dynamodbv2.document.spec.GetItemSpec
+import slatekit.results.Outcome
+import slatekit.results.builders.Outcomes
+
+
+open class AwsCloudDoc<TPartition, TCluster>(override val partition:TPartition,
+                                             override val cluster:TCluster,
+                                             override val fields:Map<String, Any?>,
+                                             override val source:Any
+) : CloudDoc<TPartition, TCluster> {
+
+    constructor(partition:TPartition,
+                cluster:TCluster,
+                fields:Map<String, Any?>): this(partition, cluster, fields, fields)
+}
+
+
+class AwsCloudDocs<TPartition, TCluster>(
+        val region:String,
+        val tableName: String,
+        val partitionName:String,
+        val clusterName:String,
+        creds: AWSCredentials) : CloudDocs<TPartition, TCluster>{
+
+
+    private val client = AmazonDynamoDBClientBuilder.standard().withCredentials(AWSStaticCredentialsProvider(creds)).build()
+    private val dynamoDB = DynamoDB(client)
+    private val table = dynamoDB.getTable(tableName)
+
+
+    override fun create(doc: CloudDoc<TPartition, TCluster>) {
+        try {
+            val item = Item().withPrimaryKey(partitionName, doc.partition, clusterName, doc.cluster)
+            doc.fields.forEach { name, value ->
+                when(value) {
+                    null       -> item.withNull(name)
+                    is Int     -> item.withInt(name, value )
+                    is String  -> item.withString(name, value )
+                    is Boolean -> item.withBoolean(name, value )
+                    else       -> item.withString(name, value.toString())
+                }
+            }
+            val outcome = table.putItem(item)
+            println("PutItem succeeded:\n" + outcome.putItemResult)
+
+        } catch (e: Exception) {
+            System.err.println("Unable to add item: ${doc.partition} ${doc.cluster}")
+            System.err.println(e.message)
+        }
+
+    }
+
+    override fun get(partition: TPartition): Outcome<CloudDoc<TPartition, TCluster>> {
+        return Outcomes.invalid()
+    }
+
+    override fun get(partition: TPartition, cluster: TCluster): Outcome<CloudDoc<TPartition, TCluster>> {
+        val spec = GetItemSpec().withPrimaryKey(partitionName, partition, clusterName, cluster)
+
+        return try {
+            println("Attempting to read the item...")
+            val item = table.getItem(spec)
+            println("GetItem succeeded: $item")
+            val doc = AwsCloudDoc(partition, cluster, item.asMap(), item)
+            Outcomes.success(doc)
+        } catch (ex: Exception) {
+            System.err.println("Unable to read item: $partition $cluster")
+            System.err.println(ex.message)
+            Outcomes.unexpected(ex)
+        }
+    }
+
+    override fun update(doc: CloudDoc<TPartition, TCluster>)  {
+
+    }
+
+    override fun delete(doc: CloudDoc<TPartition, TCluster>) {
+    }
+}

--- a/src/lib/kotlin/slatekit-cloud/src/main/kotlin/slatekit/cloud/aws/AwsCloudDocs.kt
+++ b/src/lib/kotlin/slatekit-cloud/src/main/kotlin/slatekit/cloud/aws/AwsCloudDocs.kt
@@ -11,8 +11,6 @@ import com.amazonaws.services.dynamodbv2.document.Item
 import com.amazonaws.services.dynamodbv2.document.spec.GetItemSpec
 import slatekit.results.Outcome
 import slatekit.results.builders.Outcomes
-import com.sun.xml.internal.fastinfoset.alphabet.BuiltInRestrictedAlphabets.table
-import com.amazonaws.services.dynamodbv2.document.utils.ValueMap
 import com.amazonaws.services.dynamodbv2.document.PrimaryKey
 import com.amazonaws.services.dynamodbv2.document.spec.DeleteItemSpec
 

--- a/src/lib/kotlin/slatekit-cloud/src/main/kotlin/slatekit/cloud/aws/AwsCloudDocs.kt
+++ b/src/lib/kotlin/slatekit-cloud/src/main/kotlin/slatekit/cloud/aws/AwsCloudDocs.kt
@@ -11,6 +11,12 @@ import com.amazonaws.services.dynamodbv2.document.Item
 import com.amazonaws.services.dynamodbv2.document.spec.GetItemSpec
 import slatekit.results.Outcome
 import slatekit.results.builders.Outcomes
+import com.sun.xml.internal.fastinfoset.alphabet.BuiltInRestrictedAlphabets.table
+import com.amazonaws.services.dynamodbv2.document.utils.ValueMap
+import com.amazonaws.services.dynamodbv2.document.PrimaryKey
+import com.amazonaws.services.dynamodbv2.document.spec.DeleteItemSpec
+
+
 
 
 open class AwsCloudDoc<TPartition, TCluster>(override val partition:TPartition,
@@ -85,5 +91,19 @@ class AwsCloudDocs<TPartition, TCluster>(
     }
 
     override fun delete(doc: CloudDoc<TPartition, TCluster>) {
+        val deleteItemSpec = DeleteItemSpec()
+                .withPrimaryKey(PrimaryKey(partitionName, doc.partition, clusterName, doc.cluster))
+
+        // Conditional delete (we expect this to fail)
+
+        try {
+            println("Attempting a conditional delete...")
+            table.deleteItem(deleteItemSpec)
+            println("DeleteItem succeeded")
+        } catch (e: Exception) {
+            System.err.println("Unable to delete item: ${doc.partition} ${doc.cluster}")
+            System.err.println(e.message)
+        }
+
     }
 }

--- a/src/lib/kotlin/slatekit-core/src/main/kotlin/slatekit/core/cloud/CloudDocs.kt
+++ b/src/lib/kotlin/slatekit-core/src/main/kotlin/slatekit/core/cloud/CloudDocs.kt
@@ -1,0 +1,22 @@
+package slatekit.core.slatekit.core.cloud
+
+import slatekit.results.Outcome
+
+interface CloudDoc<TPartition, TCluster> {
+    val partition:TPartition
+
+    val cluster:TCluster
+
+    val fields:Map<String, Any?>
+
+    val source:Any
+}
+
+
+interface CloudDocs<TPartition, TCluster> {
+    fun create(doc:CloudDoc<TPartition, TCluster>)
+    fun get(partition:TPartition): Outcome<CloudDoc<TPartition, TCluster>>
+    fun get(partition:TPartition, cluster:TCluster): Outcome<CloudDoc<TPartition, TCluster>>
+    fun update(doc:CloudDoc<TPartition, TCluster>)
+    fun delete(doc:CloudDoc<TPartition, TCluster>)
+}

--- a/src/lib/kotlin/slatekit-core/src/main/kotlin/slatekit/core/cloud/CloudDocs.kt
+++ b/src/lib/kotlin/slatekit-core/src/main/kotlin/slatekit/core/cloud/CloudDocs.kt
@@ -2,7 +2,7 @@ package slatekit.core.slatekit.core.cloud
 
 import slatekit.results.Outcome
 
-interface CloudDoc<TPartition, TCluster> {
+interface CloudDoc<TEntity, TPartition, TCluster> {
     val partition:TPartition
 
     val cluster:TCluster
@@ -13,10 +13,10 @@ interface CloudDoc<TPartition, TCluster> {
 }
 
 
-interface CloudDocs<TPartition, TCluster> {
-    fun create(doc:CloudDoc<TPartition, TCluster>)
-    fun get(partition:TPartition): Outcome<CloudDoc<TPartition, TCluster>>
-    fun get(partition:TPartition, cluster:TCluster): Outcome<CloudDoc<TPartition, TCluster>>
-    fun update(doc:CloudDoc<TPartition, TCluster>)
-    fun delete(doc:CloudDoc<TPartition, TCluster>)
+interface CloudDocs<TEntity, TPartition, TCluster> {
+    fun create(entity: TEntity)  : Outcome<TEntity>
+    fun update(entity:TEntity)   : Outcome<TEntity>
+    fun delete(entity:TEntity)   : Outcome<TEntity>
+    fun get(partition:TPartition): Outcome<TEntity>
+    fun get(partition:TPartition, cluster:TCluster): Outcome<TEntity>
 }


### PR DESCRIPTION
## Overview
Cloud Document Database support via AWS Dynamo

## Ticket(s) 
n/a

## Links(s) 
n/a

## Dependencies
AWS Dynamo DB SDK

## Design
1. AWSCloudDoc is generalized via [TEntity, TPartition, TCluster]
2. Simple DynamoMapper to map to/from entities to Dynamo Item objects

## Notes
n/a

## Pending
need to add several methods for completeness
1. get by x 
2.  find by x 
3. update
4. delete by x


## Tests
n/a