### PR TITLE
ADD: API - Support for call options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ branches:
     - /^release.*$/ 
 
 jdk:
-  - oraclejdk8
+  - oraclejdk9
 
 before_script:
 - echo "hello from slatekit"

--- a/src/lib/kotlin/slatekit-apis/src/main/kotlin/slatekit/apis/core/Exec.kt
+++ b/src/lib/kotlin/slatekit-apis/src/main/kotlin/slatekit/apis/core/Exec.kt
@@ -19,12 +19,13 @@ import slatekit.apis.middleware.Tracked
 import slatekit.common.log.Logger
 import slatekit.common.toResponse
 import slatekit.results.Try
+import slatekit.results.builders.Notices
 import slatekit.results.builders.Tries
 
 /**
  * Executes the API action using a pipeline of steps
  */
-class Exec(val ctx: Ctx, val validator: Validation, val logger: Logger) {
+class Exec(val ctx: Ctx, val validator: Validation, val logger: Logger, val options: ExecOptions?) {
     private val BEFORE = "Before"
     private val AFTER = "After "
 
@@ -130,7 +131,11 @@ class Exec(val ctx: Ctx, val validator: Validation, val logger: Logger) {
     inline fun auth(proceed: () -> Try<Any>): Try<Any> {
         return log("Exec::auth.name") {
 
-            val check = validator.validateAuthorization(ctx.req, ctx.apiRef)
+            val check = if(options != null && !options.auth) {
+                Notices.success(true)
+            } else {
+                validator.validateAuthorization(ctx.req, ctx.apiRef)
+            }
             val result = if (check.success) {
                 proceed()
             } else {

--- a/src/lib/kotlin/slatekit-apis/src/main/kotlin/slatekit/apis/core/ExecOptions.kt
+++ b/src/lib/kotlin/slatekit-apis/src/main/kotlin/slatekit/apis/core/ExecOptions.kt
@@ -1,0 +1,4 @@
+package slatekit.apis.core
+
+data class ExecOptions(val auth:Boolean = true,
+                       val middleware:Boolean = true)


### PR DESCRIPTION
## Overview
Added minimal support for different call options on the ApiHost.

## Ticket(s) 
n/a

## Links(s) 
n/a

## Dependencies
n/a

## Design
1. Some of the API requests could be coming from a queue, particularly a trusted queue. In this case, it doesn't make sense to authenticate


## Notes
This is a small fix as part of a larger change ( more options/changes are upcoming )

## Pending
n/a

## Tests
n/a
