### PR TITLE
MOVE: slatekit commands, syncs, tasks into slatekit.functions

### DIFF
--- a/src/lib/kotlin/slatekit-examples/build.gradle
+++ b/src/lib/kotlin/slatekit-examples/build.gradle
@@ -22,8 +22,8 @@ compileKotlin {
 
     kotlinOptions {
         jvmTarget = "1.8"
-        apiVersion = "1.1"
-        languageVersion = "1.1"
+        apiVersion = "1.3"
+        languageVersion = "1.3"
     }
 }
 
@@ -57,6 +57,7 @@ dependencies {
     compile project(":slatekit-entities")
     compile project(":slatekit-orm")
     compile project(":slatekit-core")
+    compile project(":slatekit-functions")
     compile project(":slatekit-notifications")
     compile project(":slatekit-apis")
     compile project(":slatekit-jobs")

--- a/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_App.kt
+++ b/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_App.kt
@@ -12,6 +12,7 @@
 package slatekit.examples
 
 //<doc:import_required>
+import kotlinx.coroutines.runBlocking
 import slatekit.common.Context
 import slatekit.app.AppOptions
 import slatekit.app.App
@@ -30,9 +31,8 @@ import slatekit.common.info.Build
 import slatekit.common.info.StartInfo
 import slatekit.common.info.Sys
 import slatekit.common.log.LogsDefault
-import slatekit.core.cmds.Command
-import slatekit.common.CommonContext
-import slatekit.core.cmds.CommandRequest
+import slatekit.functions.cmds.Command
+import slatekit.functions.cmds.CommandRequest
 import slatekit.db.Db
 import slatekit.entities.Entities
 import slatekit.integration.common.AppEntContext
@@ -72,7 +72,7 @@ class SampleApp(ctx: Context) : App<Context>(ctx, AppOptions(
     /**
      * Life-cycle init hook: for your app to perform any initialization
      */
-    override fun init(): Try<Boolean> {
+    override suspend fun init(): Try<Boolean> {
         println("app initialized")
         return Success(true)
     }
@@ -83,7 +83,7 @@ class SampleApp(ctx: Context) : App<Context>(ctx, AppOptions(
      *
      * @return
      */
-    override fun execute(): Try<Any> {
+    override suspend fun exec(): Try<Any> {
         // The AppContext ( ctx ) is required for the AppProcess and will be
         // available for derived classes to access its components.
 
@@ -133,7 +133,7 @@ class SampleApp(ctx: Context) : App<Context>(ctx, AppOptions(
     /**
      * Life-cycle end hook: called when app is shutting down
      */
-    override fun end(): Try<Boolean> {
+    override suspend fun end(): Try<Boolean> {
         info("app shutting down")
         return Success(true)
     }
@@ -194,7 +194,9 @@ class Example_App : Command("app") {
         )
         // Now run the app with context info with
         // the help of the AppRunner which will call the life-cycle events.
-        AppRunner.run(SampleApp(ctx))
+        runBlocking {
+            AppRunner.run(SampleApp(ctx))
+        }
 
 
         // APPROACH 2: Automatically build the AppContext using the AppRunner.build function
@@ -209,14 +211,16 @@ class Example_App : Command("app") {
         // - Env : By default, the first supported environment is used which is local "env.local"
         // - Conf: By default, the config file associated w/ the environment is loaded "env.local.conf"
         // - You can store info about the your app in your config file and that can be loaded.
-        val res = AppRunner.run(
-                rawArgs = request.args.raw.toTypedArray(),
-                schema = ArgsSchema(),
-                enc = Encryptor("wejklhviuxywehjk", "3214maslkdf03292", B64Java8),
-                logs = LogbackLogs(),
-                about = About.none,
-                builder = { ctx -> SampleApp(ctx) }
-        )
+        val res = runBlocking {
+            AppRunner.run(
+                    rawArgs = request.args.raw.toTypedArray(),
+                    schema = ArgsSchema(),
+                    enc = Encryptor("wejklhviuxywehjk", "3214maslkdf03292", B64Java8),
+                    logs = LogbackLogs(),
+                    about = About.none,
+                    builder = { ctx -> SampleApp(ctx) }
+            )
+        }
         return res
         //</doc:examples>
     }

--- a/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Args.kt
+++ b/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Args.kt
@@ -18,8 +18,8 @@ import slatekit.common.args.ArgsSchema
 //</doc:import_required>
 
 //<doc:import_examples>
-import slatekit.core.cmds.Command
-import slatekit.core.cmds.CommandRequest
+import slatekit.functions.cmds.Command
+import slatekit.functions.cmds.CommandRequest
 import slatekit.results.Success
 import slatekit.results.Try
 import slatekit.results.getOrElse

--- a/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Auth.kt
+++ b/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Auth.kt
@@ -20,8 +20,8 @@ import slatekit.common.auth.User
 //</doc:import_required>
 
 //<doc:import_examples>
-import slatekit.core.cmds.Command
-import slatekit.core.cmds.CommandRequest
+import slatekit.functions.cmds.Command
+import slatekit.functions.cmds.CommandRequest
 import slatekit.results.Try
 import slatekit.results.Success
 

--- a/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Aws_S3.kt
+++ b/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Aws_S3.kt
@@ -7,8 +7,8 @@ import slatekit.cloud.aws.AwsCloudFiles
 //</doc:import_required>
 
 //<doc:import_examples>
-import slatekit.core.cmds.Command
-import slatekit.core.cmds.CommandRequest
+import slatekit.functions.cmds.Command
+import slatekit.functions.cmds.CommandRequest
 import slatekit.results.Success
 import slatekit.results.Try
 

--- a/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Aws_Sqs.kt
+++ b/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Aws_Sqs.kt
@@ -20,8 +20,8 @@ import slatekit.common.queues.QueueStringConverter
 //</doc:import_required>
 
 //<doc:import_examples>
-import slatekit.core.cmds.Command
-import slatekit.core.cmds.CommandRequest
+import slatekit.functions.cmds.Command
+import slatekit.functions.cmds.CommandRequest
 import slatekit.results.Success
 import slatekit.results.Try
 

--- a/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_CLI.kt
+++ b/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_CLI.kt
@@ -27,8 +27,8 @@ import slatekit.common.requests.InputArgs
 import slatekit.common.requests.Request
 import slatekit.results.Try
 import slatekit.results.Success
-import slatekit.core.cmds.Command
-import slatekit.core.cmds.CommandRequest
+import slatekit.functions.cmds.Command
+import slatekit.functions.cmds.CommandRequest
 import slatekit.results.Status
 import slatekit.results.StatusCodes
 

--- a/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Cache.kt
+++ b/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Cache.kt
@@ -20,8 +20,8 @@ import slatekit.core.cache.CacheSettings
 //</doc:import_required>
 
 //<doc:import_examples>
-import slatekit.core.cmds.Command
-import slatekit.core.cmds.CommandRequest
+import slatekit.functions.cmds.Command
+import slatekit.functions.cmds.CommandRequest
 import slatekit.results.Try
 import slatekit.results.Success
 

--- a/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Command.kt
+++ b/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Command.kt
@@ -13,15 +13,15 @@
 package slatekit.examples
 
 //<doc:import_required>
-import slatekit.core.cmds.Command
-import slatekit.core.cmds.CommandRequest
+import slatekit.functions.cmds.Command
+import slatekit.functions.cmds.CommandRequest
 
 //</doc:import_required>
 
 //<doc:import_examples>
 import slatekit.results.Try
 import slatekit.results.Success
-import slatekit.core.cmds.Commands
+import slatekit.functions.cmds.Commands
 
 //</doc:import_examples>
 

--- a/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Config.kt
+++ b/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Config.kt
@@ -22,8 +22,8 @@ import slatekit.common.conf.Config
 import slatekit.common.db.DbCon
 import slatekit.common.encrypt.B64Java8
 import slatekit.common.encrypt.Encryptor
-import slatekit.core.cmds.Command
-import slatekit.core.cmds.CommandRequest
+import slatekit.functions.cmds.Command
+import slatekit.functions.cmds.CommandRequest
 
 //</doc:import_examples>
 

--- a/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Console.kt
+++ b/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Console.kt
@@ -18,9 +18,9 @@ import slatekit.common.console.*
 //</doc:import_required>
 
 //<doc:import_examples>
-import slatekit.core.cmds.Command
+import slatekit.functions.cmds.Command
 import slatekit.common.DateTime
-import slatekit.core.cmds.CommandRequest
+import slatekit.functions.cmds.CommandRequest
 import slatekit.results.Try
 import slatekit.results.Success
 //</doc:import_examples>

--- a/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_ConsoleWeb.kt
+++ b/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_ConsoleWeb.kt
@@ -20,8 +20,8 @@ package slatekit.examples
 import slatekit.common.DateTime
 import slatekit.common.Uris
 import slatekit.common.console.*
-import slatekit.core.cmds.Command
-import slatekit.core.cmds.CommandRequest
+import slatekit.functions.cmds.Command
+import slatekit.functions.cmds.CommandRequest
 import slatekit.results.Try
 import slatekit.results.Success
 import java.io.File

--- a/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Context.kt
+++ b/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Context.kt
@@ -30,8 +30,8 @@ import slatekit.common.log.LogsDefault
 import slatekit.common.Context
 import slatekit.common.envs.Envs
 import slatekit.entities.Entities
-import slatekit.core.cmds.Command
-import slatekit.core.cmds.CommandRequest
+import slatekit.functions.cmds.Command
+import slatekit.functions.cmds.CommandRequest
 import slatekit.db.Db
 import slatekit.integration.common.AppEntContext
 import slatekit.results.StatusCodes

--- a/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Database.kt
+++ b/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Database.kt
@@ -20,8 +20,8 @@ import slatekit.common.db.DbConString
 //<doc:import_examples>
 import slatekit.results.Try
 import slatekit.results.Success
-import slatekit.core.cmds.Command
-import slatekit.core.cmds.CommandRequest
+import slatekit.functions.cmds.Command
+import slatekit.functions.cmds.CommandRequest
 import slatekit.examples.common.User
 import slatekit.meta.models.ModelMapper
 import slatekit.orm.OrmMapper

--- a/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_DateTime.kt
+++ b/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_DateTime.kt
@@ -17,13 +17,13 @@ import slatekit.common.DateTimes
 //</doc:import_required>
 
 //<doc:import_examples>
-import slatekit.core.cmds.Command
+import slatekit.functions.cmds.Command
 import slatekit.results.Try
 import slatekit.results.Success
 //import java.time.ZoneId
 import org.threeten.bp.*
 import slatekit.common.ext.*
-import slatekit.core.cmds.CommandRequest
+import slatekit.functions.cmds.CommandRequest
 
 //</doc:import_examples>
 

--- a/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_DbLookup.kt
+++ b/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_DbLookup.kt
@@ -25,8 +25,8 @@ import slatekit.common.db.DbConString
 import slatekit.common.db.DbLookup
 import slatekit.common.db.DbLookup.Companion.defaultDb
 import slatekit.common.db.DbLookup.Companion.namedDbs
-import slatekit.core.cmds.Command
-import slatekit.core.cmds.CommandRequest
+import slatekit.functions.cmds.Command
+import slatekit.functions.cmds.CommandRequest
 
 //</doc:import_examples>
 

--- a/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Diagnostics.kt
+++ b/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Diagnostics.kt
@@ -24,8 +24,8 @@ import slatekit.common.log.LoggerConsole
 import slatekit.common.metrics.MetricsLite
 import slatekit.common.requests.Response
 import slatekit.common.CommonResponse
-import slatekit.core.cmds.Command
-import slatekit.core.cmds.CommandRequest
+import slatekit.functions.cmds.Command
+import slatekit.functions.cmds.CommandRequest
 import slatekit.results.Try
 import slatekit.results.Success
 

--- a/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Email.kt
+++ b/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Email.kt
@@ -22,10 +22,10 @@ import slatekit.common.templates.Templates
 
 //<doc:import_examples>
 import slatekit.results.Try
-import slatekit.core.cmds.Command
+import slatekit.functions.cmds.Command
 import slatekit.common.conf.Config
 import slatekit.common.info.ApiLogin
-import slatekit.core.cmds.CommandRequest
+import slatekit.functions.cmds.CommandRequest
 
 //</doc:import_examples>
 

--- a/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Encryptor.kt
+++ b/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Encryptor.kt
@@ -17,8 +17,8 @@ import slatekit.common.encrypt.B64Java8
 //</doc:import_required>
 
 //<doc:import_examples>
-import slatekit.core.cmds.Command
-import slatekit.core.cmds.CommandRequest
+import slatekit.functions.cmds.Command
+import slatekit.functions.cmds.CommandRequest
 import slatekit.results.Try
 import slatekit.results.Success
 //</doc:import_examples>

--- a/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Entities.kt
+++ b/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Entities.kt
@@ -17,8 +17,8 @@ import slatekit.common.*
 //</doc:import_required>
 
 //<doc:import_examples>
-import slatekit.core.cmds.Command
-import slatekit.core.cmds.CommandRequest
+import slatekit.functions.cmds.Command
+import slatekit.functions.cmds.CommandRequest
 import slatekit.entities.*
 import slatekit.results.Try
 import slatekit.results.Success

--- a/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Entities_Reg.kt
+++ b/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Entities_Reg.kt
@@ -24,8 +24,8 @@ import slatekit.common.conf.ConfFuncs
 import slatekit.common.db.DbConString
 import slatekit.common.db.DbLookup
 import slatekit.common.db.DbType
-import slatekit.core.cmds.Command
-import slatekit.core.cmds.CommandRequest
+import slatekit.functions.cmds.Command
+import slatekit.functions.cmds.CommandRequest
 import slatekit.db.Db
 import slatekit.examples.common.User
 import slatekit.examples.common.UserRepository

--- a/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Entities_Repo.kt
+++ b/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Entities_Repo.kt
@@ -19,8 +19,8 @@ import slatekit.common.*
 //<doc:import_examples>
 import slatekit.db.Db
 import slatekit.common.db.DbConString
-import slatekit.core.cmds.Command
-import slatekit.core.cmds.CommandRequest
+import slatekit.functions.cmds.Command
+import slatekit.functions.cmds.CommandRequest
 import slatekit.entities.EntityMapper
 import slatekit.entities.EntityWithId
 import slatekit.entities.repos.EntityRepoInMemoryWithLongId

--- a/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Entities_Service.kt
+++ b/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Entities_Service.kt
@@ -22,8 +22,8 @@ import slatekit.results.Try
 import slatekit.results.Success
 import slatekit.db.Db
 import slatekit.common.db.DbConString
-import slatekit.core.cmds.Command
-import slatekit.core.cmds.CommandRequest
+import slatekit.functions.cmds.Command
+import slatekit.functions.cmds.CommandRequest
 import slatekit.entities.*
 import slatekit.entities.repos.EntityRepoInMemoryWithLongId
 import slatekit.meta.models.ModelMapper

--- a/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Env.kt
+++ b/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Env.kt
@@ -18,8 +18,8 @@ import slatekit.common.envs.*
 //</doc:import_required>
 
 //<doc:import_examples>
-import slatekit.core.cmds.Command
-import slatekit.core.cmds.CommandRequest
+import slatekit.functions.cmds.Command
+import slatekit.functions.cmds.CommandRequest
 import slatekit.results.Try
 import slatekit.results.Success
 

--- a/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Folders.kt
+++ b/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Folders.kt
@@ -19,8 +19,8 @@ import slatekit.common.info.Folders
 //<doc:import_examples>
 import slatekit.results.Try
 import slatekit.results.Success
-import slatekit.core.cmds.Command
-import slatekit.core.cmds.CommandRequest
+import slatekit.functions.cmds.Command
+import slatekit.functions.cmds.CommandRequest
 
 //</doc:import_examples>
 

--- a/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_IO.kt
+++ b/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_IO.kt
@@ -15,8 +15,8 @@ package slatekit.examples
 //</doc:import_required>
 
 //<doc:import_examples>
-import slatekit.core.cmds.Command
-import slatekit.core.cmds.CommandRequest
+import slatekit.functions.cmds.Command
+import slatekit.functions.cmds.CommandRequest
 import slatekit.results.Try
 import slatekit.results.Success
 

--- a/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Info.kt
+++ b/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Info.kt
@@ -19,11 +19,11 @@ import slatekit.common.info.StartInfo
 //</doc:import_required>
 
 //<doc:import_examples>
-import slatekit.core.cmds.Command
+import slatekit.functions.cmds.Command
 import slatekit.results.Try
 import slatekit.results.Success
 import slatekit.common.envs.EnvMode
-import slatekit.core.cmds.CommandRequest
+import slatekit.functions.cmds.CommandRequest
 
 //</doc:import_examples>
 

--- a/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Lexer.kt
+++ b/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Lexer.kt
@@ -19,8 +19,8 @@ import slatekit.common.lex.TokenType
 //</doc:import_required>
 
 //<doc:import_examples>
-import slatekit.core.cmds.Command
-import slatekit.core.cmds.CommandRequest
+import slatekit.functions.cmds.Command
+import slatekit.functions.cmds.CommandRequest
 import slatekit.results.Try
 import slatekit.results.Success
 

--- a/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Logger.kt
+++ b/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Logger.kt
@@ -18,8 +18,8 @@ import slatekit.common.log.*
 //</doc:import_required>
 
 //<doc:import_examples>
-import slatekit.core.cmds.Command
-import slatekit.core.cmds.CommandRequest
+import slatekit.functions.cmds.Command
+import slatekit.functions.cmds.CommandRequest
 import slatekit.results.Try
 import slatekit.results.Success
 

--- a/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Mapper.kt
+++ b/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Mapper.kt
@@ -16,8 +16,8 @@ package slatekit.examples
 import slatekit.common.*
 import slatekit.common.db.DbCon
 import slatekit.meta.models.Model
-import slatekit.core.cmds.Command
-import slatekit.core.cmds.CommandRequest
+import slatekit.functions.cmds.Command
+import slatekit.functions.cmds.CommandRequest
 import slatekit.db.Db
 import slatekit.entities.EntityWithId
 import slatekit.examples.common.User

--- a/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Model.kt
+++ b/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Model.kt
@@ -17,13 +17,13 @@ import slatekit.meta.models.*
 //</doc:import_required>
 
 //<doc:import_examples>
-import slatekit.core.cmds.Command
+import slatekit.functions.cmds.Command
 import slatekit.common.DateTime
 import slatekit.results.Try
 import slatekit.results.Success
 import slatekit.common.auth.User
 import slatekit.common.info.Host
-import slatekit.core.cmds.CommandRequest
+import slatekit.functions.cmds.CommandRequest
 import slatekit.orm.databases.vendors.MySqlBuilder
 
 //</doc:import_examples>

--- a/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Queue.kt
+++ b/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Queue.kt
@@ -17,12 +17,12 @@ package slatekit.examples
 //</doc:import_required>
 
 //<doc:import_examples>
-import slatekit.core.cmds.Command
+import slatekit.functions.cmds.Command
 import slatekit.results.Try
 import slatekit.results.Success
 import slatekit.common.queues.QueueSourceInMemory
 import slatekit.common.queues.QueueStringConverter
-import slatekit.core.cmds.CommandRequest
+import slatekit.functions.cmds.CommandRequest
 
 //</doc:import_examples>
 

--- a/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Random.kt
+++ b/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Random.kt
@@ -28,8 +28,8 @@ import slatekit.common.Random.stringN
 //</doc:import_required>
 
 //<doc:import_examples>
-import slatekit.core.cmds.Command
-import slatekit.core.cmds.CommandRequest
+import slatekit.functions.cmds.Command
+import slatekit.functions.cmds.CommandRequest
 import slatekit.results.Try
 import slatekit.results.Success
 

--- a/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Reflect.kt
+++ b/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Reflect.kt
@@ -22,8 +22,8 @@ import slatekit.meta.Reflector
 //</doc:import_required>
 
 //<doc:import_examples>
-import slatekit.core.cmds.Command
-import slatekit.core.cmds.CommandRequest
+import slatekit.functions.cmds.Command
+import slatekit.functions.cmds.CommandRequest
 import slatekit.results.Try
 import slatekit.results.Success
 import slatekit.examples.common.User

--- a/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Request.kt
+++ b/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Request.kt
@@ -20,8 +20,8 @@ import slatekit.common.requests.Source
 //</doc:import_required>
 
 //<doc:import_examples>
-import slatekit.core.cmds.Command
-import slatekit.core.cmds.CommandRequest
+import slatekit.functions.cmds.Command
+import slatekit.functions.cmds.CommandRequest
 import slatekit.results.Try
 import slatekit.results.Success
 //</doc:import_examples>

--- a/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Results.kt
+++ b/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Results.kt
@@ -16,8 +16,8 @@ package slatekit.examples
 //</doc:import_required>
 
 //<doc:import_examples>
-import slatekit.core.cmds.Command
-import slatekit.core.cmds.CommandRequest
+import slatekit.functions.cmds.Command
+import slatekit.functions.cmds.CommandRequest
 import slatekit.results.*
 import slatekit.results.Try
 import slatekit.results.Success

--- a/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Serialization.kt
+++ b/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Serialization.kt
@@ -18,8 +18,8 @@ import slatekit.common.serialization.*
 //</doc:import_required>
 
 //<doc:import_examples>
-import slatekit.core.cmds.Command
-import slatekit.core.cmds.CommandRequest
+import slatekit.functions.cmds.Command
+import slatekit.functions.cmds.CommandRequest
 import slatekit.examples.common.User
 
 //</doc:import_examples>

--- a/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_SmartValues.kt
+++ b/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_SmartValues.kt
@@ -18,8 +18,8 @@ import slatekit.results.Success
 //</doc:import_required>
 
 //<doc:import_examples>
-import slatekit.core.cmds.Command
-import slatekit.core.cmds.CommandRequest
+import slatekit.functions.cmds.Command
+import slatekit.functions.cmds.CommandRequest
 import slatekit.results.Outcome
 
 //</doc:import_examples>

--- a/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Sms.kt
+++ b/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Sms.kt
@@ -17,14 +17,14 @@ import slatekit.common.*
 //</doc:import_required>
 
 //<doc:import_examples>
-import slatekit.core.cmds.Command
+import slatekit.functions.cmds.Command
 import slatekit.common.templates.Template
 import slatekit.common.templates.TemplatePart
 import slatekit.common.templates.Templates
 import slatekit.common.conf.Config
 import slatekit.common.info.ApiLogin
 import slatekit.common.types.CountryCode
-import slatekit.core.cmds.CommandRequest
+import slatekit.functions.cmds.CommandRequest
 import slatekit.notifications.sms.SmsMessage
 import slatekit.notifications.sms.SmsServiceTwilio
 import slatekit.results.Try

--- a/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Templates.kt
+++ b/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Templates.kt
@@ -20,9 +20,9 @@ import slatekit.common.templates.Templates
 //</doc:import_required>
 
 //<doc:import_examples>
-import slatekit.core.cmds.Command
+import slatekit.functions.cmds.Command
 import slatekit.common.Random
-import slatekit.core.cmds.CommandRequest
+import slatekit.functions.cmds.CommandRequest
 import slatekit.results.Try
 import slatekit.results.getOrElse
 

--- a/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Todo.kt
+++ b/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Todo.kt
@@ -18,8 +18,8 @@ import slatekit.common.TODO
 //</doc:import_required>
 
 //<doc:import_examples>
-import slatekit.core.cmds.Command
-import slatekit.core.cmds.CommandRequest
+import slatekit.functions.cmds.Command
+import slatekit.functions.cmds.CommandRequest
 import slatekit.results.Success
 import slatekit.results.Try
 

--- a/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Utils.kt
+++ b/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Utils.kt
@@ -21,11 +21,11 @@ import slatekit.common.*
 //</doc:import_required>
 
 //<doc:import_examples>
-import slatekit.core.cmds.Command
+import slatekit.functions.cmds.Command
 import slatekit.common.db.DbConString
 import slatekit.common.info.ApiKey
 import slatekit.common.info.ApiLogin
-import slatekit.core.cmds.CommandRequest
+import slatekit.functions.cmds.CommandRequest
 import slatekit.results.Try
 import slatekit.results.Success
 

--- a/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Validation.kt
+++ b/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Validation.kt
@@ -19,7 +19,7 @@ import slatekit.common.validations.ValidationResults
 //</doc:import_required>
 
 //<doc:import_examples>
-import slatekit.core.cmds.Command
+import slatekit.functions.cmds.Command
 import slatekit.results.Try
 import slatekit.results.Success
 import slatekit.common.validations.ValidationFuncs.isEmpty
@@ -42,7 +42,7 @@ import slatekit.common.validations.ValidationFuncs.isNumeric
 import slatekit.common.validations.ValidationFuncs.isPhoneUS
 import slatekit.common.validations.ValidationFuncs.isUrl
 import slatekit.common.validations.ValidationFuncs.isZipCodeUS
-import slatekit.core.cmds.CommandRequest
+import slatekit.functions.cmds.CommandRequest
 
 //</doc:import_examples>
 

--- a/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Workers.kt
+++ b/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Workers.kt
@@ -21,9 +21,9 @@ import slatekit.common.metrics.MetricsLite
 //<doc:import_examples>
 import slatekit.common.queues.QueueSourceInMemory
 import slatekit.common.queues.QueueValueConverter
-import slatekit.core.cmds.Command
+import slatekit.functions.cmds.Command
 import slatekit.common.CommonContext
-import slatekit.core.cmds.CommandRequest
+import slatekit.functions.cmds.CommandRequest
 import slatekit.results.Try
 import slatekit.results.Success
 

--- a/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Guide_APIs.kt
+++ b/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Guide_APIs.kt
@@ -5,8 +5,8 @@ import slatekit.apis.core.Api
 import slatekit.common.conf.Config
 import slatekit.results.Try
 import slatekit.results.Success
-import slatekit.core.cmds.Command
-import slatekit.core.cmds.CommandRequest
+import slatekit.functions.cmds.Command
+import slatekit.functions.cmds.CommandRequest
 import slatekit.examples.common.*
 import slatekit.integration.common.AppEntContext
 

--- a/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/tutorial/Example_Kotlin_Basics.kt
+++ b/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/tutorial/Example_Kotlin_Basics.kt
@@ -24,7 +24,7 @@ package slatekit.tutorial
 // NOTE: An object is essentially a Singleton class
 // that serves as a "module" containing 1 or more functions
 import slatekit.common.Random.string6
-import slatekit.core.cmds.Command
+import slatekit.functions.cmds.Command
 import slatekit.results.Success
 import slatekit.results.Try
 import java.time.LocalDateTime

--- a/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/tutorial/Example_Kotlin_Classes.kt
+++ b/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/tutorial/Example_Kotlin_Classes.kt
@@ -13,7 +13,7 @@
 
 package slatekit.tutorial
 
-import slatekit.core.cmds.Command
+import slatekit.functions.cmds.Command
 import slatekit.results.Success
 import slatekit.results.Try
 

--- a/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/tutorial/Example_Kotlin_Functions.kt
+++ b/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/tutorial/Example_Kotlin_Functions.kt
@@ -15,7 +15,7 @@ package slatekit.tutorial
 
 
 import slatekit.common.TODO
-import slatekit.core.cmds.Command
+import slatekit.functions.cmds.Command
 import slatekit.results.Success
 import slatekit.results.Try
 

--- a/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/tutorial/Example_Kotlin_Misc.kt
+++ b/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/tutorial/Example_Kotlin_Misc.kt
@@ -14,7 +14,7 @@
 package slatekit.tutorial
 
 
-import slatekit.core.cmds.Command
+import slatekit.functions.cmds.Command
 import kotlin.reflect.KProperty
 import slatekit.common.ext.*
 import slatekit.results.Success

--- a/src/lib/kotlin/slatekit-functions/.gitignore
+++ b/src/lib/kotlin/slatekit-functions/.gitignore
@@ -1,0 +1,24 @@
+*.class
+*.log
+*.iml
+*.xml
+*.jar
+*.bin
+*.kotlin_module
+
+# IDE
+.cache
+.history
+.worksheet
+.idea
+.gradle
+
+# ROOT DIRS
+lib/
+build/
+dist/
+target/
+
+
+# tests
+./src/tests/kotlin/*

--- a/src/lib/kotlin/slatekit-functions/build.gradle
+++ b/src/lib/kotlin/slatekit-functions/build.gradle
@@ -1,0 +1,201 @@
+apply from: '../../../../build/gradle/slatekit-common.gradle'
+
+buildscript {
+    ext.kotlin_version = '1.3.21'
+    ext.slatekit_version = new File('../version.txt').text
+
+    repositories {
+        jcenter()
+        mavenCentral()
+    }
+    dependencies {
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.3"
+    }
+}
+
+apply plugin: 'java'
+apply plugin: 'kotlin'
+
+
+// ==================================================================
+// Slate Kit Component Info
+// ==================================================================
+def slatekitComponentId = 'functions'
+def slatekitComponentName = 'Functions'
+def slatekitComponentDesc = 'SlateKit Functions: Commands, Syncs, Scheduled Tasks'
+def slatekitComponentVersion = getCommonVersion()
+
+
+// ==================================================================
+// Slate Kit Setup mode: defaults to maven vs loading project sources
+// ==================================================================
+ext.slatekitSetupViaMaven = System.getenv('SLATEKIT_SETUP_MODE') != 'sources'
+task info {
+    println('slatekit.setup     : ' + System.getenv('SLATEKIT_SETUP_MODE'))
+    println('slatekit.maven     : ' + slatekitSetupViaMaven)
+    println('slatekit.comp.id   : ' + slatekitComponentId)
+    println('slatekit.comp.name : ' + slatekitComponentName)
+    println('slatekit.comp.desc : ' + slatekitComponentDesc)
+    println('slatekit.comp.vers : ' + slatekitComponentVersion)
+    println()
+    println('project.name       : ' + project.name)
+    println('project.path       : ' + project.path)
+    println('project.desc       : ' + project.description)
+    println('project.projectDir : ' + project.projectDir)
+    println('project.buildDir   : ' + project.buildDir)
+    println()
+    println('build.commit       : ' + gitCommitId())
+    println('build.branch       : ' + gitBranchName())
+    println('build.date         : ' + getBuildDate())
+}
+
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+
+    kotlinOptions {
+        jvmTarget = '1.8'
+        apiVersion = '1.3'
+        languageVersion = '1.3'
+    }
+}
+
+
+repositories {
+    jcenter()
+    mavenCentral()
+    maven {
+        url  "https://dl.bintray.com/codehelixinc/slatekit"
+    }
+}
+
+dependencies {
+    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+    compile 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.1.0'
+    compile 'com.squareup.okhttp3:okhttp:3.9.0'
+    compile 'org.threeten:threetenbp:1.3.8'
+
+    /* <slatekit_local>
+    if( slatekitSetupViaMaven ) {
+        compile "com.slatekit:slatekit-results:$slatekit_version"
+        compile "com.slatekit:slatekit-common:$slatekit_version"
+        compile "com.slatekit:slatekit-meta:$slatekit_version"
+    } else {
+        // */
+        compile project(":slatekit-result")
+        compile project(":slatekit-common")
+        compile project(":slatekit-meta")
+    //</slatekit_local>
+}
+
+// ==================================================================
+// BinTray Integration
+// ==================================================================
+apply plugin: 'maven'
+apply plugin: 'maven-publish'
+apply plugin: 'com.jfrog.bintray'
+
+
+// Maven packages require the sources/docs.
+task sourcesJar(type: Jar, dependsOn: classes) {
+    classifier = 'sources'
+    from sourceSets.main.allSource
+}
+
+javadoc.failOnError = false
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    classifier = 'javadoc'
+    from javadoc.destinationDir
+}
+
+artifacts {
+    archives sourcesJar
+    archives javadocJar
+}
+
+def pomConfig = {
+    licenses {
+        license {
+            name "Apache 2.0"
+            url "http://www.apache.org/licenses/LICENSE-2.0.txt"
+            distribution "repo"
+        }
+    }
+    developers {
+        developer {
+            id "codehelix"
+            name "kishore reddy"
+            email "kishore@codehelix.co"
+        }
+    }
+
+    scm {
+        url "https://github.com/code-helix/slatekit-${slatekitComponentId}"
+    }
+}
+
+publishing {
+    publications {
+        mavenPublication(MavenPublication) {
+            from components.java
+            artifact sourcesJar {
+                classifier "sources"
+            }
+            artifact javadocJar {
+                classifier "javadoc"
+            }
+            groupId 'com.slatekit'
+            artifactId "slatekit-${slatekitComponentId}"
+            version "${slatekitComponentVersion}"
+            pom.withXml {
+                def root = asNode()
+                root.appendNode('description', "${slatekitComponentDesc}")
+                root.appendNode('name', "SlateKit ${slatekitComponentName}")
+                root.appendNode('url', "https://github.com/code-helix/slatekit-${slatekitComponentId}")
+                root.children().last() + pomConfig
+            }
+        }
+    }
+}
+
+// gradle bintrayUpload
+bintray {
+
+    user = project.hasProperty('bintrayUser') ? project.property('bintrayUser') : System.getenv('SLATEKIT_BINTRAY_USER')
+    key = project.hasProperty('bintrayApiKey') ? project.property('bintrayApiKey') : System.getenv('SLATEKIT_BINTRAY_API_KEY')
+    publish = true
+    //configurations = ['archives']
+    publications = ['mavenPublication']
+    pkg {
+        repo            = "slatekit"
+        name            = "slatekit-${slatekitComponentId}"
+        userOrg         = "codehelixinc"
+        desc            = "${slatekitComponentDesc}"
+        websiteUrl      = "http://www.slatekit.com/"
+        issueTrackerUrl = "https://github.com/code-helix/slatekit-${slatekitComponentId}/issues"
+        vcsUrl          = "https://github.com/code-helix/slatekit-${slatekitComponentId}"
+        licenses        = ['Apache-2.0']
+        publicDownloadNumbers = false
+        version {
+            name = "${slatekitComponentVersion}"
+        }
+    }
+}
+
+/* ==================================================================
+*
+* DEPLOY:
+* 1. ensure bin-tray user/pswd env vars are set: bintrayUser, bintrayApiKey
+* 2. replace the version number(s) in this file
+* 3. cd into root directory
+* 4. run gradle bintrayUpload
+*
+* LINKS:
+* https://reflectoring.io/guide-publishing-to-bintray-with-gradle/
+* https://stackoverflow.com/questions/52359686/configure-gradle-for-kotlin-with-java-1-7
+*
+* ===================================================================
+*/
+

--- a/src/lib/kotlin/slatekit-functions/gradle/wrapper/gradle-wrapper.properties
+++ b/src/lib/kotlin/slatekit-functions/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,6 @@
+#Mon Oct 26 12:25:13 CET 2015
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.7-all.zip

--- a/src/lib/kotlin/slatekit-functions/gradlew
+++ b/src/lib/kotlin/slatekit-functions/gradlew
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+
+##############################################################################
+##
+##  Gradle start up script for UN*X
+##
+##############################################################################
+
+# Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
+DEFAULT_JVM_OPTS=""
+
+APP_NAME="Gradle"
+APP_BASE_NAME=`basename "$0"`
+
+# Use the maximum available, or set MAX_FD != -1 to use that value.
+MAX_FD="maximum"
+
+warn ( ) {
+    echo "$*"
+}
+
+die ( ) {
+    echo
+    echo "$*"
+    echo
+    exit 1
+}
+
+# OS specific support (must be 'true' or 'false').
+cygwin=false
+msys=false
+darwin=false
+case "`uname`" in
+  CYGWIN* )
+    cygwin=true
+    ;;
+  Darwin* )
+    darwin=true
+    ;;
+  MINGW* )
+    msys=true
+    ;;
+esac
+
+# For Cygwin, ensure paths are in UNIX format before anything is touched.
+if $cygwin ; then
+    [ -n "$JAVA_HOME" ] && JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
+fi
+
+# Attempt to set APP_HOME
+# Resolve links: $0 may be a link
+PRG="$0"
+# Need this for relative symlinks.
+while [ -h "$PRG" ] ; do
+    ls=`ls -ld "$PRG"`
+    link=`expr "$ls" : '.*-> \(.*\)$'`
+    if expr "$link" : '/.*' > /dev/null; then
+        PRG="$link"
+    else
+        PRG=`dirname "$PRG"`"/$link"
+    fi
+done
+SAVED="`pwd`"
+cd "`dirname \"$PRG\"`/" >&-
+APP_HOME="`pwd -P`"
+cd "$SAVED" >&-
+
+CLASSPATH=$APP_HOME/gradle/wrapper/gradle-wrapper.jar
+
+# Determine the Java command to use to start the JVM.
+if [ -n "$JAVA_HOME" ] ; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
+        # IBM's JDK on AIX uses strange locations for the executables
+        JAVACMD="$JAVA_HOME/jre/sh/java"
+    else
+        JAVACMD="$JAVA_HOME/bin/java"
+    fi
+    if [ ! -x "$JAVACMD" ] ; then
+        die "ERROR: JAVA_HOME is set to an invalid directory: $JAVA_HOME
+
+Please set the JAVA_HOME variable in your environment to match the
+location of your Java installation."
+    fi
+else
+    JAVACMD="java"
+    which java >/dev/null 2>&1 || die "ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
+
+Please set the JAVA_HOME variable in your environment to match the
+location of your Java installation."
+fi
+
+# Increase the maximum file descriptors if we can.
+if [ "$cygwin" = "false" -a "$darwin" = "false" ] ; then
+    MAX_FD_LIMIT=`ulimit -H -n`
+    if [ $? -eq 0 ] ; then
+        if [ "$MAX_FD" = "maximum" -o "$MAX_FD" = "max" ] ; then
+            MAX_FD="$MAX_FD_LIMIT"
+        fi
+        ulimit -n $MAX_FD
+        if [ $? -ne 0 ] ; then
+            warn "Could not set maximum file descriptor limit: $MAX_FD"
+        fi
+    else
+        warn "Could not query maximum file descriptor limit: $MAX_FD_LIMIT"
+    fi
+fi
+
+# For Darwin, add options to specify how the application appears in the dock
+if $darwin; then
+    GRADLE_OPTS="$GRADLE_OPTS \"-Xdock:name=$APP_NAME\" \"-Xdock:icon=$APP_HOME/media/gradle.icns\""
+fi
+
+# For Cygwin, switch paths to Windows format before running java
+if $cygwin ; then
+    APP_HOME=`cygpath --path --mixed "$APP_HOME"`
+    CLASSPATH=`cygpath --path --mixed "$CLASSPATH"`
+
+    # We build the pattern for arguments to be converted via cygpath
+    ROOTDIRSRAW=`find -L / -maxdepth 1 -mindepth 1 -type d 2>/dev/null`
+    SEP=""
+    for dir in $ROOTDIRSRAW ; do
+        ROOTDIRS="$ROOTDIRS$SEP$dir"
+        SEP="|"
+    done
+    OURCYGPATTERN="(^($ROOTDIRS))"
+    # Add a user-defined pattern to the cygpath arguments
+    if [ "$GRADLE_CYGPATTERN" != "" ] ; then
+        OURCYGPATTERN="$OURCYGPATTERN|($GRADLE_CYGPATTERN)"
+    fi
+    # Now convert the arguments - kludge to limit ourselves to /bin/sh
+    i=0
+    for arg in "$@" ; do
+        CHECK=`echo "$arg"|egrep -c "$OURCYGPATTERN" -`
+        CHECK2=`echo "$arg"|egrep -c "^-"`                                 ### Determine if an option
+
+        if [ $CHECK -ne 0 ] && [ $CHECK2 -eq 0 ] ; then                    ### Added a condition
+            eval `echo args$i`=`cygpath --path --ignore --mixed "$arg"`
+        else
+            eval `echo args$i`="\"$arg\""
+        fi
+        i=$((i+1))
+    done
+    case $i in
+        (0) set -- ;;
+        (1) set -- "$args0" ;;
+        (2) set -- "$args0" "$args1" ;;
+        (3) set -- "$args0" "$args1" "$args2" ;;
+        (4) set -- "$args0" "$args1" "$args2" "$args3" ;;
+        (5) set -- "$args0" "$args1" "$args2" "$args3" "$args4" ;;
+        (6) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" ;;
+        (7) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" "$args6" ;;
+        (8) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" "$args6" "$args7" ;;
+        (9) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" "$args6" "$args7" "$args8" ;;
+    esac
+fi
+
+# Split up the JVM_OPTS And GRADLE_OPTS values into an array, following the shell quoting and substitution rules
+function splitJvmOpts() {
+    JVM_OPTS=("$@")
+}
+eval splitJvmOpts $DEFAULT_JVM_OPTS $JAVA_OPTS $GRADLE_OPTS
+JVM_OPTS[${#JVM_OPTS[*]}]="-Dorg.gradle.appname=$APP_BASE_NAME"
+
+exec "$JAVACMD" "${JVM_OPTS[@]}" -classpath "$CLASSPATH" org.gradle.wrapper.GradleWrapperMain "$@"

--- a/src/lib/kotlin/slatekit-functions/gradlew.bat
+++ b/src/lib/kotlin/slatekit-functions/gradlew.bat
@@ -1,0 +1,90 @@
+@if "%DEBUG%" == "" @echo off
+@rem ##########################################################################
+@rem
+@rem  Gradle startup script for Windows
+@rem
+@rem ##########################################################################
+
+@rem Set local scope for the variables with windows NT shell
+if "%OS%"=="Windows_NT" setlocal
+
+@rem Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
+set DEFAULT_JVM_OPTS=
+
+set DIRNAME=%~dp0
+if "%DIRNAME%" == "" set DIRNAME=.
+set APP_BASE_NAME=%~n0
+set APP_HOME=%DIRNAME%
+
+@rem Find java.exe
+if defined JAVA_HOME goto findJavaFromJavaHome
+
+set JAVA_EXE=java.exe
+%JAVA_EXE% -version >NUL 2>&1
+if "%ERRORLEVEL%" == "0" goto init
+
+echo.
+echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
+echo.
+echo Please set the JAVA_HOME variable in your environment to match the
+echo location of your Java installation.
+
+goto fail
+
+:findJavaFromJavaHome
+set JAVA_HOME=%JAVA_HOME:"=%
+set JAVA_EXE=%JAVA_HOME%/bin/java.exe
+
+if exist "%JAVA_EXE%" goto init
+
+echo.
+echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME%
+echo.
+echo Please set the JAVA_HOME variable in your environment to match the
+echo location of your Java installation.
+
+goto fail
+
+:init
+@rem Get command-line arguments, handling Windowz variants
+
+if not "%OS%" == "Windows_NT" goto win9xME_args
+if "%@eval[2+2]" == "4" goto 4NT_args
+
+:win9xME_args
+@rem Slurp the command line arguments.
+set CMD_LINE_ARGS=
+set _SKIP=2
+
+:win9xME_args_slurp
+if "x%~1" == "x" goto execute
+
+set CMD_LINE_ARGS=%*
+goto execute
+
+:4NT_args
+@rem Get arguments from the 4NT Shell from JP Software
+set CMD_LINE_ARGS=%$
+
+:execute
+@rem Setup the command line
+
+set CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
+
+@rem Execute Gradle
+"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %CMD_LINE_ARGS%
+
+:end
+@rem End local scope for the variables with windows NT shell
+if "%ERRORLEVEL%"=="0" goto mainEnd
+
+:fail
+rem Set variable GRADLE_EXIT_CONSOLE if you need the _script_ return code instead of
+rem the _cmd.exe /c_ return code!
+if  not "" == "%GRADLE_EXIT_CONSOLE%" exit 1
+exit /b 1
+
+:mainEnd
+if "%OS%"=="Windows_NT" endlocal
+
+:omega

--- a/src/lib/kotlin/slatekit-functions/settings.gradle
+++ b/src/lib/kotlin/slatekit-functions/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'slatekit-functions'

--- a/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/cmds/Command.kt
+++ b/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/cmds/Command.kt
@@ -11,7 +11,7 @@
  * </slate_header>
  */
 
-package slatekit.core.cmds
+package slatekit.functions.cmds
 
 import slatekit.common.DateTime
 import slatekit.common.args.Args

--- a/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/cmds/CommandRequest.kt
+++ b/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/cmds/CommandRequest.kt
@@ -1,4 +1,4 @@
-package slatekit.core.cmds
+package slatekit.functions.cmds
 
 import slatekit.common.DateTime
 import slatekit.common.Inputs

--- a/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/cmds/CommandResult.kt
+++ b/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/cmds/CommandResult.kt
@@ -11,7 +11,7 @@
  * </slate_header>
  */
 
-package slatekit.core.cmds
+package slatekit.functions.cmds
 
 import slatekit.common.DateTime
 import slatekit.common.functions.FunctionInfo

--- a/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/cmds/CommandState.kt
+++ b/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/cmds/CommandState.kt
@@ -11,7 +11,7 @@
  * </slate_header>
  */
 
-package slatekit.core.syncs
+package slatekit.functions.cmds
 
 import slatekit.common.DateTime
 import slatekit.common.DateTimes
@@ -29,7 +29,7 @@ import slatekit.common.metrics.MetricsLite
  * @param hasRun : Whether command has run at least once
  * @param lastResult : The last result
  */
-data class SyncState(
+data class CommandState(
         override val info: FunctionInfo,
         override val status: Status,
         override val msg: String,
@@ -37,8 +37,8 @@ data class SyncState(
         override val lastMode: FunctionMode,
         override val hasRun: Boolean,
         override val metrics: Metrics,
-        override val lastResult: SyncResult?
-) : FunctionState<SyncResult> {
+        override val lastResult: CommandResult?
+) : FunctionState<CommandResult> {
 
     /**
      * Builds a copy of the this state with bumped up numbers ( run count, error count, etc )
@@ -46,16 +46,15 @@ data class SyncState(
      * @param result
      * @return
      */
-    fun update(result: SyncResult): SyncState {
+    fun update(result: CommandResult): CommandState {
 
         val updated = this.copy(
-                msg = result.message,
-                lastMode = result.mode,
+                msg = result.message ?: "",
                 lastRun = result.started,
+                lastMode = result.mode,
                 hasRun = true,
                 lastResult = result
         )
-
         // Update the metrics based on the slatekit.results.status.code
         // which is standardized across all modules
         updated.increment(result.result.code, null)
@@ -69,13 +68,13 @@ data class SyncState(
          * @param name
          * @return
          */
-        fun empty(info: FunctionInfo): SyncState =
-                SyncState(
+        fun empty(info: FunctionInfo): CommandState =
+                CommandState(
                         info = info,
                         status = Status.InActive,
                         msg = "Not yet run",
-                        lastMode = FunctionMode.Called,
                         lastRun = DateTimes.MIN,
+                        lastMode = FunctionMode.Called,
                         hasRun = false,
                         metrics = MetricsLite(),
                         lastResult = null

--- a/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/cmds/Commands.kt
+++ b/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/cmds/Commands.kt
@@ -11,7 +11,7 @@
  * </slate_header>
  */
 
-package slatekit.core.cmds
+package slatekit.functions.cmds
 
 import slatekit.common.args.Args
 import slatekit.common.functions.FunctionInfo

--- a/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/common/HttpCoroutine.kt
+++ b/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/common/HttpCoroutine.kt
@@ -1,0 +1,62 @@
+package slatekit.functions.common
+
+import okhttp3.Response
+import slatekit.common.HttpRPC
+import slatekit.results.Notice
+import slatekit.results.Outcome
+import slatekit.results.Try
+import slatekit.results.builders.Notices
+import slatekit.results.builders.Outcomes
+import slatekit.results.builders.Tries
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlin.coroutines.suspendCoroutine
+
+
+
+suspend fun awaitHttp(callback: (HttpRPC.HttpRPCResult) -> Unit ) : Response {
+    return suspendCoroutine { cont ->
+        callback(object : HttpRPC.HttpRPCResult {
+            override fun onSuccess(result: Response) = cont.resume(result)
+            override fun onFailure(e: Exception?) {
+                e?.let { cont.resumeWithException(it) }
+            }
+        })
+    }
+}
+
+
+suspend fun awaitHttpTry(callback: (HttpRPC.HttpRPCResult) -> Unit ) : Try<Response> {
+    return suspendCoroutine { cont ->
+        callback(object : HttpRPC.HttpRPCResult {
+            override fun onSuccess(result: Response) = cont.resume(Tries.success(result))
+            override fun onFailure(e: Exception?) {
+                e?.let { cont.resume(Tries.errored(e)) }
+            }
+        })
+    }
+}
+
+
+suspend fun awaitHttpOutcome(callback: (HttpRPC.HttpRPCResult) -> Unit ) : Outcome<Response> {
+    return suspendCoroutine { cont ->
+        callback(object : HttpRPC.HttpRPCResult {
+            override fun onSuccess(result: Response) = cont.resume(Outcomes.success(result))
+            override fun onFailure(e: Exception?) {
+                e?.let { cont.resume(Outcomes.errored(e)) }
+            }
+        })
+    }
+}
+
+
+suspend fun awaitHttpNotice(callback: (HttpRPC.HttpRPCResult) -> Unit ) : Notice<Response> {
+    return suspendCoroutine { cont ->
+        callback(object : HttpRPC.HttpRPCResult {
+            override fun onSuccess(result: Response) = cont.resume(Notices.success(result))
+            override fun onFailure(e: Exception?) {
+                e?.let { cont.resume(Notices.errored(e)) }
+            }
+        })
+    }
+}

--- a/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/scheduler/ErrorMode.kt
+++ b/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/scheduler/ErrorMode.kt
@@ -1,4 +1,4 @@
-package slatekit.core.scheduler
+package slatekit.functions.scheduler
 
 sealed class ErrorMode(val name:String, val value:Int, val desc:String) {
     object Strict   : ErrorMode("Strict"  , 0, "No errors allowed, an exception will fail the task")

--- a/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/scheduler/RunMode.kt
+++ b/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/scheduler/RunMode.kt
@@ -1,4 +1,4 @@
-package slatekit.core.scheduler
+package slatekit.functions.scheduler
 
 sealed class RunMode(val name:String, val value:Int, val desc:String) {
     object  Periodic : RunMode("Periodic", 0, "Runs periodically")

--- a/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/scheduler/Task.kt
+++ b/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/scheduler/Task.kt
@@ -1,4 +1,4 @@
-package slatekit.core.scheduler
+package slatekit.functions.scheduler
 
 import slatekit.common.toId
 import slatekit.common.Status

--- a/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/scheduler/TaskDiagnostics.kt
+++ b/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/scheduler/TaskDiagnostics.kt
@@ -1,4 +1,4 @@
-package slatekit.core.scheduler
+package slatekit.functions.scheduler
 
 import slatekit.common.Diagnostics
 import slatekit.common.log.Logger

--- a/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/scheduler/TaskRequest.kt
+++ b/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/scheduler/TaskRequest.kt
@@ -1,6 +1,6 @@
-package slatekit.core.scheduler
+package slatekit.functions.scheduler
 
 import slatekit.common.DateTime
-import slatekit.core.scheduler.Task
+import slatekit.functions.scheduler.Task
 
 data class TaskRequest(val task:Task, val timestamp: DateTime)

--- a/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/scheduler/TaskScheduler.kt
+++ b/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/scheduler/TaskScheduler.kt
@@ -1,4 +1,4 @@
-package slatekit.core.scheduler
+package slatekit.functions.scheduler
 
 import slatekit.common.*
 import slatekit.common.log.Logs
@@ -25,7 +25,7 @@ class TaskScheduler(val settings: SchedulerSettings,
                     val service: ScheduledExecutorService = Executors.newScheduledThreadPool(2)) {
 
     /**
-     * Logger for this scheduler ( logger name="slatekit.core.scheduler.TaskScheduler" )
+     * Logger for this scheduler ( logger name="slatekit.functions.scheduler.TaskScheduler" )
      */
     val logger = logs.getLogger(this.javaClass)
 

--- a/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/scheduler/TaskSchedulerSettings.kt
+++ b/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/scheduler/TaskSchedulerSettings.kt
@@ -1,3 +1,3 @@
-package slatekit.core.scheduler
+package slatekit.functions.scheduler
 
 data class SchedulerSettings(val name:String)

--- a/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/syncs/Sync.kt
+++ b/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/syncs/Sync.kt
@@ -1,4 +1,4 @@
-package slatekit.core.syncs
+package slatekit.functions.syncs
 
 import slatekit.common.DateTime
 import slatekit.common.ext.durationFrom

--- a/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/syncs/SyncCallback.kt
+++ b/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/syncs/SyncCallback.kt
@@ -1,4 +1,4 @@
-package slatekit.core.syncs
+package slatekit.functions.syncs
 
 import slatekit.results.Notice
 

--- a/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/syncs/SyncResult.kt
+++ b/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/syncs/SyncResult.kt
@@ -1,4 +1,4 @@
-package slatekit.core.syncs
+package slatekit.functions.syncs
 
 import slatekit.common.DateTime
 import slatekit.common.functions.FunctionInfo

--- a/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/syncs/SyncSettings.kt
+++ b/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/syncs/SyncSettings.kt
@@ -1,4 +1,4 @@
-package slatekit.core.syncs
+package slatekit.functions.syncs
 
 
 class SyncSettings(val enabled: Boolean, val reloadInSeconds: Int, val tag: String)

--- a/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/syncs/SyncState.kt
+++ b/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/syncs/SyncState.kt
@@ -11,7 +11,7 @@
  * </slate_header>
  */
 
-package slatekit.core.cmds
+package slatekit.functions.syncs
 
 import slatekit.common.DateTime
 import slatekit.common.DateTimes
@@ -29,7 +29,7 @@ import slatekit.common.metrics.MetricsLite
  * @param hasRun : Whether command has run at least once
  * @param lastResult : The last result
  */
-data class CommandState(
+data class SyncState(
         override val info: FunctionInfo,
         override val status: Status,
         override val msg: String,
@@ -37,8 +37,8 @@ data class CommandState(
         override val lastMode: FunctionMode,
         override val hasRun: Boolean,
         override val metrics: Metrics,
-        override val lastResult: CommandResult?
-) : FunctionState<CommandResult> {
+        override val lastResult: SyncResult?
+) : FunctionState<SyncResult> {
 
     /**
      * Builds a copy of the this state with bumped up numbers ( run count, error count, etc )
@@ -46,15 +46,16 @@ data class CommandState(
      * @param result
      * @return
      */
-    fun update(result: CommandResult): CommandState {
+    fun update(result: SyncResult): SyncState {
 
         val updated = this.copy(
-                msg = result.message ?: "",
-                lastRun = result.started,
+                msg = result.message,
                 lastMode = result.mode,
+                lastRun = result.started,
                 hasRun = true,
                 lastResult = result
         )
+
         // Update the metrics based on the slatekit.results.status.code
         // which is standardized across all modules
         updated.increment(result.result.code, null)
@@ -68,13 +69,13 @@ data class CommandState(
          * @param name
          * @return
          */
-        fun empty(info: FunctionInfo): CommandState =
-                CommandState(
+        fun empty(info: FunctionInfo): SyncState =
+                SyncState(
                         info = info,
                         status = Status.InActive,
                         msg = "Not yet run",
-                        lastRun = DateTimes.MIN,
                         lastMode = FunctionMode.Called,
+                        lastRun = DateTimes.MIN,
                         hasRun = false,
                         metrics = MetricsLite(),
                         lastResult = null

--- a/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/syncs/Syncs.kt
+++ b/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/syncs/Syncs.kt
@@ -1,4 +1,4 @@
-package slatekit.core.syncs
+package slatekit.functions.syncs
 
 import slatekit.common.functions.FunctionInfo
 import slatekit.common.functions.Functions

--- a/src/lib/kotlin/slatekit/build.gradle
+++ b/src/lib/kotlin/slatekit/build.gradle
@@ -110,6 +110,7 @@ dependencies {
         implementation project(":slatekit-query")
         implementation project(":slatekit-cloud")
         implementation project(":slatekit-entities")
+        implementation project(":slatekit-functions")
         implementation project(":slatekit-orm")
         implementation project(":slatekit-core")
         implementation project(":slatekit-notifications")

--- a/src/lib/kotlin/slatekit/settings.gradle
+++ b/src/lib/kotlin/slatekit/settings.gradle
@@ -27,6 +27,9 @@ project(':slatekit-orm').projectDir=new File('../slatekit-orm')
 include ':slatekit-core'
 project(':slatekit-core').projectDir=new File('../slatekit-core')
 
+include ':slatekit-functions'
+project(':slatekit-functions').projectDir=new File('../slatekit-functions')
+
 include ':slatekit-apis'
 project(':slatekit-apis').projectDir=new File('../slatekit-apis')
 

--- a/src/lib/kotlin/slatekit/src/main/kotlin/slatekit/SlateKitServices.kt
+++ b/src/lib/kotlin/slatekit/src/main/kotlin/slatekit/SlateKitServices.kt
@@ -7,10 +7,10 @@ import slatekit.cloud.aws.AwsCloudQueue
 import slatekit.common.queues.QueueStringConverter
 import slatekit.core.cloud.CloudFiles
 import slatekit.core.cloud.CloudQueue
-import slatekit.core.email.EmailService
-import slatekit.core.email.EmailServiceSendGrid
-import slatekit.core.sms.SmsService
-import slatekit.core.sms.SmsServiceTwilio
+import slatekit.notifications.email.EmailService
+import slatekit.notifications.email.EmailServiceSendGrid
+import slatekit.notifications.sms.SmsService
+import slatekit.notifications.sms.SmsServiceTwilio
 import slatekit.docs.DocApi
 import slatekit.info.DependencyApi
 import slatekit.info.DependencyModule


### PR DESCRIPTION
## Overview
Move the **slatekit.core: commands, syncs, scheduled tasks** into the new **slatekit.functions** project.

## Ticket(s) 
https://github.com/code-helix/slatekit/issues/192

## Links(s) 
n/a

## Dependencies
1. new project has same dependencies as slatekit.core

## Design
1. only moved packages into new project.

## Notes
1. Most changes are simply the Examples updated with the new package ( 50+ files )
2. consider what to do with the slatekit.common.functions package which provides the foundation for the commands, syncs, and scheduled tasks.

## Pending
1. possibly clean up the diagnostics on the slatekit.common.functions 

## Tests
<!-- Any tests added/changed -->
