### PR TITLE
MOVE: slatekit.common.functions to new functions project

### DIFF
--- a/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/cmds/Command.kt
+++ b/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/cmds/Command.kt
@@ -15,10 +15,8 @@ package slatekit.functions.cmds
 
 import slatekit.common.DateTime
 import slatekit.common.args.Args
-import slatekit.common.functions.Function
-import slatekit.common.functions.FunctionTriggers
-import slatekit.common.functions.FunctionInfo
-import slatekit.common.functions.FunctionMode
+import slatekit.functions.common.Function
+import slatekit.functions.common.*
 import slatekit.results.*
 import slatekit.results.builders.Tries
 import java.util.concurrent.atomic.AtomicReference

--- a/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/cmds/CommandResult.kt
+++ b/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/cmds/CommandResult.kt
@@ -14,9 +14,7 @@
 package slatekit.functions.cmds
 
 import slatekit.common.DateTime
-import slatekit.common.functions.FunctionInfo
-import slatekit.common.functions.FunctionMode
-import slatekit.common.functions.FunctionResult
+import slatekit.functions.common.*
 import slatekit.results.Result
 import slatekit.results.builders.Tries
 

--- a/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/cmds/CommandState.kt
+++ b/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/cmds/CommandState.kt
@@ -16,9 +16,7 @@ package slatekit.functions.cmds
 import slatekit.common.DateTime
 import slatekit.common.DateTimes
 import slatekit.common.Status
-import slatekit.common.functions.FunctionInfo
-import slatekit.common.functions.FunctionMode
-import slatekit.common.functions.FunctionState
+import slatekit.functions.common.*
 import slatekit.common.metrics.Metrics
 import slatekit.common.metrics.MetricsLite
 

--- a/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/cmds/Commands.kt
+++ b/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/cmds/Commands.kt
@@ -14,9 +14,7 @@
 package slatekit.functions.cmds
 
 import slatekit.common.args.Args
-import slatekit.common.functions.FunctionInfo
-import slatekit.common.functions.FunctionMode
-import slatekit.common.functions.Functions
+import slatekit.functions.common.*
 import slatekit.results.Failure
 import slatekit.results.Success
 import slatekit.results.builders.Tries

--- a/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/common/Function.kt
+++ b/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/common/Function.kt
@@ -1,4 +1,4 @@
-package slatekit.common.functions
+package slatekit.functions.common
 
 
 interface Function {

--- a/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/common/FunctionInfo.kt
+++ b/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/common/FunctionInfo.kt
@@ -1,4 +1,4 @@
-package slatekit.common.functions
+package slatekit.functions.common
 
 import slatekit.common.Random
 import slatekit.common.toId

--- a/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/common/FunctionMode.kt
+++ b/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/common/FunctionMode.kt
@@ -1,4 +1,4 @@
-package slatekit.common.functions
+package slatekit.functions.common
 
 
 enum class FunctionMode constructor(val value: Int) {

--- a/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/common/FunctionResult.kt
+++ b/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/common/FunctionResult.kt
@@ -1,4 +1,4 @@
-package slatekit.common.functions
+package slatekit.functions.common
 
 import slatekit.common.DateTime
 import slatekit.common.ext.durationFrom

--- a/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/common/FunctionState.kt
+++ b/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/common/FunctionState.kt
@@ -1,4 +1,4 @@
-package slatekit.common.functions
+package slatekit.functions.common
 
 import slatekit.common.DateTime
 import slatekit.common.Status
@@ -12,7 +12,7 @@ import slatekit.results.isInSuccessRange
 /**
  * Stores the state of the function execution
  */
-interface FunctionState<out T> where T:FunctionResult{
+interface FunctionState<out T> where T: FunctionResult {
     /**
      * Information about the function
      */

--- a/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/common/FunctionTriggers.kt
+++ b/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/common/FunctionTriggers.kt
@@ -1,4 +1,4 @@
-package slatekit.common.functions
+package slatekit.functions.common
 
 
 interface FunctionTriggers<out Result> {

--- a/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/common/FunctionType.kt
+++ b/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/common/FunctionType.kt
@@ -1,4 +1,4 @@
-package slatekit.common.functions
+package slatekit.functions.common
 
 import slatekit.common.EnumLike
 

--- a/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/common/Functions.kt
+++ b/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/common/Functions.kt
@@ -1,4 +1,4 @@
-package slatekit.common.functions
+package slatekit.functions.common
 
 
 /**

--- a/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/syncs/Sync.kt
+++ b/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/syncs/Sync.kt
@@ -4,13 +4,10 @@ import slatekit.common.DateTime
 import slatekit.common.ext.durationFrom
 import slatekit.common.log.LogSupport
 import slatekit.common.log.Logger
-import slatekit.common.functions.Function
-import slatekit.common.functions.FunctionTriggers
-import slatekit.common.functions.FunctionInfo
-import slatekit.common.functions.FunctionMode
+import slatekit.functions.common.*
+import slatekit.functions.common.Function
 import slatekit.results.Notice
 import slatekit.results.Success
-import slatekit.results.Try
 import slatekit.results.builders.Notices
 import slatekit.results.builders.Tries
 import slatekit.results.getOrElse

--- a/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/syncs/SyncResult.kt
+++ b/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/syncs/SyncResult.kt
@@ -1,9 +1,7 @@
 package slatekit.functions.syncs
 
 import slatekit.common.DateTime
-import slatekit.common.functions.FunctionInfo
-import slatekit.common.functions.FunctionMode
-import slatekit.common.functions.FunctionResult
+import slatekit.functions.common.*
 import slatekit.results.Result
 import slatekit.results.builders.Tries
 

--- a/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/syncs/SyncState.kt
+++ b/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/syncs/SyncState.kt
@@ -16,9 +16,7 @@ package slatekit.functions.syncs
 import slatekit.common.DateTime
 import slatekit.common.DateTimes
 import slatekit.common.Status
-import slatekit.common.functions.FunctionInfo
-import slatekit.common.functions.FunctionMode
-import slatekit.common.functions.FunctionState
+import slatekit.functions.common.*
 import slatekit.common.metrics.Metrics
 import slatekit.common.metrics.MetricsLite
 

--- a/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/syncs/Syncs.kt
+++ b/src/lib/kotlin/slatekit-functions/src/main/kotlin/slatekit/functions/syncs/Syncs.kt
@@ -1,7 +1,7 @@
 package slatekit.functions.syncs
 
-import slatekit.common.functions.FunctionInfo
-import slatekit.common.functions.Functions
+import slatekit.functions.common.FunctionInfo
+import slatekit.functions.common.Functions
 import slatekit.results.builders.Notices
 import slatekit.results.builders.Tries
 import slatekit.results.getOrElse

--- a/src/lib/kotlin/slatekit-integration/build.gradle
+++ b/src/lib/kotlin/slatekit-integration/build.gradle
@@ -91,6 +91,8 @@ dependencies {
         compile "com.slatekit:slatekit-core:$slatekit_version"
         compile "com.slatekit:slatekit-apis:$slatekit_version"
         compile "com.slatekit:slatekit-jobs:$slatekit_version"
+        compile "com.slatekit:slatekit-functions:$slatekit_version"
+        compile "com.slatekit:slatekit-notifications:$slatekit_version"
     } else {
         // */
         compile project(":slatekit-result")
@@ -101,8 +103,10 @@ dependencies {
         compile project(":slatekit-entities")
         compile project(":slatekit-orm")
         compile project(":slatekit-core")
+        compile project(":slatekit-functions")
         compile project(":slatekit-apis")
         compile project(":slatekit-jobs")
+        compile project(":slatekit-notifications")
     //</slatekit_local>
 }
 

--- a/src/lib/kotlin/slatekit-integration/src/main/kotlin/slatekit/integration/apis/CmdApi.kt
+++ b/src/lib/kotlin/slatekit-integration/src/main/kotlin/slatekit/integration/apis/CmdApi.kt
@@ -18,9 +18,9 @@ import slatekit.apis.ApiAction
 import slatekit.apis.security.AuthModes
 import slatekit.apis.security.Protocols
 import slatekit.apis.security.Verbs
-import slatekit.core.cmds.CommandResult
-import slatekit.core.cmds.CommandState
-import slatekit.core.cmds.Commands
+import slatekit.functions.cmds.CommandResult
+import slatekit.functions.cmds.CommandState
+import slatekit.functions.cmds.Commands
 import slatekit.common.CommonContext
 import slatekit.results.Try
 

--- a/src/lib/kotlin/slatekit-integration/src/main/kotlin/slatekit/integration/apis/EmailApi.kt
+++ b/src/lib/kotlin/slatekit-integration/src/main/kotlin/slatekit/integration/apis/EmailApi.kt
@@ -22,7 +22,7 @@ import slatekit.apis.support.ApiWithSupport
 import slatekit.common.Context
 import slatekit.common.Uris
 import slatekit.common.Vars
-import slatekit.core.email.EmailService
+import slatekit.notifications.email.EmailService
 import slatekit.results.Outcome
 
 @Api(area = "cloud", name = "email", desc = "api to send emails",

--- a/src/lib/kotlin/slatekit-integration/src/main/kotlin/slatekit/integration/apis/SmsApi.kt
+++ b/src/lib/kotlin/slatekit-integration/src/main/kotlin/slatekit/integration/apis/SmsApi.kt
@@ -21,7 +21,7 @@ import slatekit.apis.security.Verbs
 import slatekit.apis.support.ApiWithSupport
 import slatekit.common.Context
 import slatekit.common.Vars
-import slatekit.core.sms.SmsService
+import slatekit.notifications.sms.SmsService
 import slatekit.results.Outcome
 import slatekit.results.Try
 

--- a/src/lib/kotlin/slatekit-tests/build.gradle
+++ b/src/lib/kotlin/slatekit-tests/build.gradle
@@ -59,6 +59,7 @@ dependencies {
     implementation project(":slatekit-core")
     implementation project(":slatekit-apis")
     implementation project(":slatekit-jobs")
+    implementation project(":slatekit-functions")
     implementation project(":slatekit-integration")
     implementation project(":slatekit-cloud")
     implementation project(":slatekit-providers")

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/core/SyncTests.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/core/SyncTests.kt
@@ -2,8 +2,8 @@ package test.core
 
 import org.junit.Assert
 import org.junit.Test
-import slatekit.common.functions.FunctionMode
-import slatekit.core.syncs.Sync
+import slatekit.functions.common.FunctionMode
+import slatekit.functions.syncs.Sync
 import slatekit.results.builders.Notices
 
 class SyncTests {


### PR DESCRIPTION
## Overview
Move the existing **slatekit.common.functions** package into the new **slatekit.functions** into package `slatekit.functions.common`. The functions are a set of common components to represent and wrap a callback/lambda/ for the **Commands, Syncs, Scheduled Tasks** in the slatekit functions project.

## Ticket(s) 
https://github.com/code-helix/slatekit/issues/192

## Links(s) 
n/a

## Dependencies
n/a

## Design
Just moved the base classes/traits etc into the new project.

## Notes
n/a

## Pending
Some cleanup of the diagnostics is still pending

## Tests
Tests updated with new project/package info
