### PR TITLE
ADD: API support for calling suspend method via reflection

### DIFF
--- a/src/lib/kotlin/slatekit-apis/src/main/kotlin/slatekit/apis/ApiServer.kt
+++ b/src/lib/kotlin/slatekit-apis/src/main/kotlin/slatekit/apis/ApiServer.kt
@@ -20,6 +20,7 @@ import slatekit.results.*
 import slatekit.results.Status
 import slatekit.results.builders.Notices
 import slatekit.results.builders.Outcomes
+import java.lang.reflect.Method
 
 /**
  * This is the core container hosting, managing and executing the source independent apis.
@@ -251,7 +252,7 @@ open class ApiServer(
         val converter = settings.decoder?.invoke(req, ctx.enc) ?: Deserializer(req, ctx.enc)
         val inputs = fillArgs(converter, target, req)
 
-        val returnVal = Reflector.callMethod(target.api.cls, target.instance, target.action.member.name, inputs)
+        val returnVal = Calls.callMethod(target.api.cls, target.instance, target.action.member.name, inputs)
 
         val wrapped = returnVal?.let { res ->
             if (res is Result<*, *>) {
@@ -262,6 +263,7 @@ open class ApiServer(
         } ?: Outcomes.of(Exception("Received null"))
         return wrapped
     }
+
 
     private val typeDefaults = mapOf(
         "String" to "",

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/meta/SuspendTests.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/meta/SuspendTests.kt
@@ -1,0 +1,43 @@
+package test.meta
+
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert
+import org.junit.Test
+import slatekit.apis.core.Calls
+
+class SuspendTests {
+
+    @Test
+    fun callSuspend(){
+        val sample = ReflectSample()
+        runBlocking {
+            val result = Calls.callMethod(ReflectSample::class, sample, "add", arrayOf(1, 2))
+            Assert.assertEquals(3, result)
+        }
+    }
+
+
+    @Test
+    fun callNormal(){
+        val sample = ReflectSample()
+        runBlocking {
+            val result = Calls.callMethod(ReflectSample::class, sample, "inc", arrayOf(1, 2))
+            Assert.assertEquals(3, result)
+        }
+    }
+}
+
+
+class ReflectSample {
+
+    suspend fun add(a: Int, b:Int):Int {
+        val result = a + b
+        return result
+    }
+
+
+    fun inc(a: Int, b:Int):Int {
+        val result = a + b
+        return result
+    }
+}


### PR DESCRIPTION
## Overview
FIX to APIs to support calling suspend method via reflection.

## Ticket(s) 
https://github.com/code-helix/slatekit/issues/183

## Links(s) 
https://stackoverflow.com/questions/47654537/how-to-run-suspend-method-via-reflection

## Dependencies
n/a

## Design
Not using existing sync **Reflect.callMethod**

## Notes
n/a

## Pending
n/a

## Tests
added 2 unit tests for sync/suspend
