### PR TITLE
Result: Status codes design changes - breaking

### DIFF
--- a/src/lib/kotlin/slatekit-apis/src/main/kotlin/slatekit/apis/core/Errs.kt
+++ b/src/lib/kotlin/slatekit-apis/src/main/kotlin/slatekit/apis/core/Errs.kt
@@ -32,10 +32,11 @@ object Errs {
         flatten(err, errors, 0)
         val json = JSONObject()
         json["success"] = false
+        json["name"] = result.name
         json["code"] = result.code
+        json["desc"] = result.desc
         json["meta"] = result.meta
         json["value"] = null
-        json["msg"] = result.msg
         json["errs"] = errors
         json["tag"] = result.tag
         return json

--- a/src/lib/kotlin/slatekit-app/src/main/kotlin/slatekit/app/AppHelp.kt
+++ b/src/lib/kotlin/slatekit-app/src/main/kotlin/slatekit/app/AppHelp.kt
@@ -59,7 +59,7 @@ class AppHelp(val about: About, val args: ArgsSchema, val envs: Envs = Envs.defa
                     appMeta.handle(assist)
 
                     // Prevent futher processing by return failure
-                    Tries.errored<Args>(Exception(assist.msg), Codes.ERRORED.copy(assist.status.name, assist.status.code, assist.status.desc))
+                    Tries.errored<Args>(Exception(assist.desc), Codes.ERRORED.copy(assist.status.name, assist.status.code, assist.status.desc))
                 }
             }
         }
@@ -81,7 +81,7 @@ class AppHelp(val about: About, val args: ArgsSchema, val envs: Envs = Envs.defa
                 Codes.HELP.code -> help()
                 Codes.ABOUT.code -> about()
                 Codes.VERSION.code -> version()
-                else -> println("Unexpected command: " + check.msg)
+                else -> println("Unexpected command: " + check.desc)
             }
         }
     }

--- a/src/lib/kotlin/slatekit-app/src/main/kotlin/slatekit/app/AppHelp.kt
+++ b/src/lib/kotlin/slatekit-app/src/main/kotlin/slatekit/app/AppHelp.kt
@@ -59,7 +59,7 @@ class AppHelp(val about: About, val args: ArgsSchema, val envs: Envs = Envs.defa
                     appMeta.handle(assist)
 
                     // Prevent futher processing by return failure
-                    Tries.errored<Args>(Exception(assist.msg), Codes.ERRORED.copy(assist.status.code, assist.status.msg))
+                    Tries.errored<Args>(Exception(assist.msg), Codes.ERRORED.copy(assist.status.name, assist.status.code, assist.status.desc))
                 }
             }
         }

--- a/src/lib/kotlin/slatekit-app/src/main/kotlin/slatekit/app/AppRunner.kt
+++ b/src/lib/kotlin/slatekit-app/src/main/kotlin/slatekit/app/AppRunner.kt
@@ -142,7 +142,7 @@ object AppRunner {
     private fun showError(result: Try<Any>, ex: Exception?) : Try<Any> {
         println("success: " + result.success)
         println("code   : " + result.code)
-        println("message: " + result.msg)
+        println("message: " + result.desc)
         ex?.let {
             println("error  : " + ex.message)
             val count = Math.min(10, ex.stackTrace.size)

--- a/src/lib/kotlin/slatekit-cli/src/main/kotlin/slatekit/cli/CLI.kt
+++ b/src/lib/kotlin/slatekit-cli/src/main/kotlin/slatekit/cli/CLI.kt
@@ -101,7 +101,7 @@ open class CLI(
         return when(status){
             is Passed.Succeeded -> Tries.success(true, status)
             is Passed.Pending   -> Tries.pending(true, status)
-            else                -> Failure(Exception(status.msg), status.msg, status.code)
+            else                -> Failure(Exception(status.desc), status.desc, status.code)
         }
     }
 

--- a/src/lib/kotlin/slatekit-cli/src/main/kotlin/slatekit/cli/CliExecutor.kt
+++ b/src/lib/kotlin/slatekit-cli/src/main/kotlin/slatekit/cli/CliExecutor.kt
@@ -63,6 +63,7 @@ open class CliExecutor {
             CliResponse(
                     request,
                     true,
+                    Codes.SUCCESS.name,
                     0,
                     mapOf(),
                     ""

--- a/src/lib/kotlin/slatekit-cli/src/main/kotlin/slatekit/cli/CliIO.kt
+++ b/src/lib/kotlin/slatekit-cli/src/main/kotlin/slatekit/cli/CliIO.kt
@@ -21,8 +21,6 @@ import slatekit.common.types.Content
 import slatekit.common.types.ContentType
 import slatekit.common.io.Files
 import slatekit.common.io.IO
-import slatekit.common.newline
-import slatekit.common.serialization.Serializer
 import slatekit.results.*
 
 open class CliIO(private val io: IO<CliOutput, Unit>,
@@ -90,7 +88,7 @@ open class CliIO(private val io: IO<CliOutput, Unit>,
         val textType = if(result.success) TextType.Success else TextType.Failure
         write(textType, "Success : " + result.success)
         text( "Status  : " + result.code)
-        text( "Message : " + result.msg)
+        text( "Message : " + result.desc)
         text( "Tag     : " + result.tag)
     }
 

--- a/src/lib/kotlin/slatekit-cli/src/main/kotlin/slatekit/cli/CliResponse.kt
+++ b/src/lib/kotlin/slatekit-cli/src/main/kotlin/slatekit/cli/CliResponse.kt
@@ -14,6 +14,7 @@ package slatekit.cli
 
 import slatekit.common.args.Args
 import slatekit.common.requests.Response
+import slatekit.results.Codes
 
 /**
  * General purpose class to model a Response at an application boundary ( such as http response )
@@ -22,19 +23,20 @@ import slatekit.common.requests.Response
  * @param code : A status code ( can be the http status code )
  * @param meta : Meta data for the response ( can be used for headers for http )
  * @param value : The actual value returned by the response
- * @param msg : Message in the case of an failure
+ * @param desc : Message in the case of an failure
  * @param err : Exception in event of failure
  * @param tag : Tag used as a correlation field
  */
 data class CliResponse<out T>(
-    val request: CliRequest,
-    override val success: Boolean,
-    override val code: Int,
-    override val meta: Map<String, String>?,
-    override val value: T?,
-    override val msg: String? = null,
-    override val err: Exception? = null,
-    override val tag: String? = null
+        val request: CliRequest,
+        override val success: Boolean,
+        override val name: String,
+        override val code: Int,
+        override val meta: Map<String, String>?,
+        override val value: T?,
+        override val desc: String? = null,
+        override val err: Exception? = null,
+        override val tag: String? = null
 ) : Response<T> {
 
     /**
@@ -50,6 +52,7 @@ data class CliResponse<out T>(
         val empty = CliResponse(
                 CliRequest.build(Args.empty(), ""),
                 true,
+                Codes.SUCCESS.name,
                 1,
                 mapOf(),
                 "empty"

--- a/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/ext/ResultExt.kt
+++ b/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/ext/ResultExt.kt
@@ -10,13 +10,13 @@ import slatekit.results.*
  */
 fun <T, E> slatekit.results.Result<T, E>.toResponse(): Response<T> {
     return when (this) {
-        is slatekit.results.Success -> CommonResponse(this.success, this.code, null, this.value, this.msg, null)
+        is slatekit.results.Success -> CommonResponse(this.success, this.status.name, this.status.code, null, this.value, this.desc, null)
         is slatekit.results.Failure -> {
             val ex: Exception = when (this.error) {
                 is Exception -> this.error as Exception
                 else -> Exception(this.error.toString())
             }
-            CommonResponse(this.success, this.code, null, null, this.msg, ex)
+            CommonResponse(this.success, this.status.name, this.status.code, null, null, this.desc, ex)
         }
     }
 }
@@ -29,7 +29,7 @@ fun slatekit.results.Result<*, *>.structured(): List<Pair<String, Any?>> {
     return listOf(
             slatekit.results.Result<*, *>::success.name to this.success,
             slatekit.results.Result<*, *>::code.name to this.code,
-            slatekit.results.Result<*, *>::msg.name to this.msg
+            slatekit.results.Result<*, *>::desc.name to this.desc
     )
 }
 

--- a/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/lex/Lexer.kt
+++ b/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/lex/Lexer.kt
@@ -29,7 +29,7 @@ open class Lexer(val text: String) {
     fun parse(): LexResult {
         val res = getTokens()
         val tokens = res.getOrElse({ listOf<Token>() })
-        return LexResult(res.success, res.msg.orEmpty(), tokens, tokens.size, false, null)
+        return LexResult(res.success, res.desc.orEmpty(), tokens, tokens.size, false, null)
     }
 
     fun getTokens(batchSize: Int = -1): Try<List<Token>> {

--- a/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/requests/CommonResponse.kt
+++ b/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/requests/CommonResponse.kt
@@ -7,16 +7,17 @@ package slatekit.common.requests
  * @param code : A status code ( can be the http status code )
  * @param meta : Meta data for the response ( can be used for headers for http )
  * @param value : The actual value returned by the response
- * @param msg : Message in the case of an failure
+ * @param desc : Message in the case of an failure
  * @param err : Exception in event of failure
  * @param tag : Tag used as a correlation field
  */
 data class CommonResponse<out T>(
         override val success: Boolean,
+        override val name: String,
         override val code: Int,
         override val meta: Map<String, String>?,
         override val value: T?,
-        override val msg: String? = null,
+        override val desc: String? = null,
         override val err: Exception? = null,
         override val tag: String? = null
 ) : Response<T> {

--- a/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/requests/Response.kt
+++ b/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/requests/Response.kt
@@ -21,10 +21,11 @@ import slatekit.results.Codes
  */
 interface Response<out T>  {
     val success: Boolean
+    val name: String
     val code: Int
     val meta: Map<String, String>?
     val value: T?
-    val msg: String?
+    val desc: String?
     val err: Exception?
     val tag: String?
 

--- a/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/serialization/Serializer.kt
+++ b/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/serialization/Serializer.kt
@@ -13,7 +13,6 @@
 
 package slatekit.common.serialization
 
-import slatekit.common.DateTime
 import slatekit.results.Result
 import slatekit.results.getOrElse
 //import java.time.*
@@ -185,7 +184,7 @@ open class Serializer(
             // Entry
             onMapItem(item, depth, 0, "success", item.success)
             onMapItem(item, depth, 1, "code", item.code)
-            onMapItem(item, depth, 2, "msg", item.msg)
+            onMapItem(item, depth, 2, "msg", item.desc)
             onMapItem(item, depth, 3, "value", item.getOrElse { null })
 
             // End

--- a/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/templates/Templates.kt
+++ b/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/templates/Templates.kt
@@ -59,7 +59,7 @@ class Templates(
                 content = text,
                 parsed = true,
                 valid = result.success,
-                status = result.msg,
+                status = result.desc,
                 group = null,
                 path = null,
                 parts = result.getOrElse({ listOf<TemplatePart>() })
@@ -123,7 +123,7 @@ class Templates(
                 resolveParts(parts, substitutions ?: subs)
             }
         } else {
-            result.msg
+            result.desc
         }
         return finalResult
     }

--- a/src/lib/kotlin/slatekit-entities/src/main/kotlin/slatekit/entities/migrations/Migrations.kt
+++ b/src/lib/kotlin/slatekit-entities/src/main/kotlin/slatekit/entities/migrations/Migrations.kt
@@ -19,7 +19,7 @@ data class SimpleMigration(
         info("Migration starting for : $id", null)
         val results = steps.map { Tries.of { it.run(db) } }
         val success = results.all { it.success }
-        val message = if (success) "" else results.first { !it.success }.msg
+        val message = if (success) "" else results.first { !it.success }.desc
         return when (success) {
             true -> {
                 info("Migration success : $id. \n $message", null)

--- a/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Args.kt
+++ b/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Args.kt
@@ -91,7 +91,7 @@ class Example_Args  : Command("args") {
     println("RESULTS:")
 
     if(!result.success) {
-      println("Error parsing args : " + result.msg)
+      println("Error parsing args : " + result.desc)
       return
     }
     val args = result.getOrElse { Args.empty() }

--- a/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_CLI.kt
+++ b/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_CLI.kt
@@ -115,10 +115,11 @@ class Example_CLI : Command("auth") {
                     CliResponse(
                             request = request,
                             success = true,
+                            name = Codes.SUCCESS.name,
                             code = Codes.SUCCESS.code,
                             meta = mapOf(),
                             value = "Sample Response",
-                            msg = "Processed",
+                            desc = "Processed",
                             err = null,
                             tag = "tag-123"
                     ))

--- a/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Diagnostics.kt
+++ b/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Diagnostics.kt
@@ -24,6 +24,7 @@ import slatekit.common.requests.CommonResponse
 import slatekit.cmds.Command
 import slatekit.cmds.CommandRequest
 import slatekit.common.Identity
+import slatekit.results.Codes
 import slatekit.tracking.Recorder
 import slatekit.results.Try
 import slatekit.results.Success
@@ -66,7 +67,7 @@ class Example_Diagnostics : Command("cmd") {
 
         // Sample response ( assume you've done processing on your sample request )
         // NOTE: The response has to be an instance of the slatekit.common.requests.Response interface
-        val result1:Response<String> = CommonResponse(true, 1000, mapOf(), "processed")
+        val result1:Response<String> = CommonResponse(true, Codes.SUCCESS.name, 1000, mapOf(), "processed")
 
         // CASE 1: Record all diagnostics  :
         // 1. log   : log the response to the logger

--- a/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Jobs.kt
+++ b/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Jobs.kt
@@ -179,7 +179,7 @@ class Example_Jobs : Command("utils"), CoroutineScope by MainScope() {
                             slatekit.jobs.Job(id.copy(service = "job6"), listOf(NewsLetterWorker()), queue2),
 
                             slatekit.jobs.Job(id.copy(service = "job7"), listOf(::sendNewsLetterWithPaging), policies = listOf(
-                                    Every(10, { req, res -> println("Paged : " + req.task.id + ":" + res.msg) }),
+                                    Every(10, { req, res -> println("Paged : " + req.task.id + ":" + res.desc) }),
                                     Limit(12, true, { req -> req.context.stats.counts }),
                                     Ratio(.1, slatekit.results.Failed.Errored(0, ""), { req -> req.context.stats.counts })
                                 )

--- a/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Jobs.kt
+++ b/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Jobs.kt
@@ -30,6 +30,7 @@ import slatekit.policy.policies.Ratio
 import slatekit.jobs.*
 import slatekit.jobs.workers.WorkResult
 import slatekit.jobs.workers.Worker
+import slatekit.results.Codes
 import slatekit.results.Try
 import slatekit.results.Success
 import java.util.concurrent.atomic.AtomicInteger
@@ -181,7 +182,7 @@ class Example_Jobs : Command("utils"), CoroutineScope by MainScope() {
                             slatekit.jobs.Job(id.copy(service = "job7"), listOf(::sendNewsLetterWithPaging), policies = listOf(
                                     Every(10, { req, res -> println("Paged : " + req.task.id + ":" + res.desc) }),
                                     Limit(12, true, { req -> req.context.stats.counts }),
-                                    Ratio(.1, slatekit.results.Failed.Errored(0, ""), { req -> req.context.stats.counts })
+                                    Ratio(.1, Codes.ERRORED, { req -> req.context.stats.counts })
                                 )
                             )
                     )

--- a/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Policy.kt
+++ b/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Policy.kt
@@ -69,7 +69,7 @@ class Example_Policy : Command("todo") {
             // Case 4: Ratio
             println("============================")
             // NOTE: The exact code/msg does not matter, only the type of the Status
-            val ratioOperation = ratio(.3, Failed.Denied(100, "")) {
+            val ratioOperation = ratio(.3, Codes.DENIED) {
                 val curr = pager.current(moveNext = true)
                 if (curr == 2) Outcomes.denied("test") else Outcomes.success(curr)
             }

--- a/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Results.kt
+++ b/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Results.kt
@@ -70,13 +70,13 @@ class Example_Results : Command("results"), OutcomeBuilder {
 
         // Pattern match on status
         when (addResult.status) {
-            is Passed.Succeeded  -> println(addResult.msg)
-            is Passed.Pending    -> println(addResult.msg)
-            is Failed.Denied     -> println(addResult.msg)
-            is Failed.Invalid    -> println(addResult.msg)
-            is Failed.Ignored    -> println(addResult.msg)
-            is Failed.Errored    -> println(addResult.msg)
-            is Failed.Unknown -> println(addResult.msg)
+            is Passed.Succeeded  -> println(addResult.desc)
+            is Passed.Pending    -> println(addResult.desc)
+            is Failed.Denied     -> println(addResult.desc)
+            is Failed.Invalid    -> println(addResult.desc)
+            is Failed.Ignored    -> println(addResult.desc)
+            is Failed.Errored    -> println(addResult.desc)
+            is Failed.Unknown -> println(addResult.desc)
         }
     }
 
@@ -157,13 +157,13 @@ class Example_Results : Command("results"), OutcomeBuilder {
         // Pattern match 2: "Mid-level" on Status ( 7 logical groups )
         // NOTE: The status property is available on both the Success/Failure branches
         when(result.status) {
-            is Passed.Succeeded  -> println(result.msg) // Success!
-            is Passed.Pending    -> println(result.msg) // Success, but in progress
-            is Failed.Denied     -> println(result.msg) // Security related
-            is Failed.Invalid    -> println(result.msg) // Bad inputs / data
-            is Failed.Ignored    -> println(result.msg) // Ignored for processing
-            is Failed.Errored    -> println(result.msg) // Expected errors
-            is Failed.Unknown -> println(result.msg) // Unexpected errors
+            is Passed.Succeeded  -> println(result.desc) // Success!
+            is Passed.Pending    -> println(result.desc) // Success, but in progress
+            is Failed.Denied     -> println(result.desc) // Security related
+            is Failed.Invalid    -> println(result.desc) // Bad inputs / data
+            is Failed.Ignored    -> println(result.desc) // Ignored for processing
+            is Failed.Errored    -> println(result.desc) // Expected errors
+            is Failed.Unknown -> println(result.desc) // Unexpected errors
         }
 
         // Pattern match 3: "Low-Level" on numeric code
@@ -384,15 +384,15 @@ class Example_Results : Command("results"), OutcomeBuilder {
         // NOTE: The status property is available on both the Success/Failure branches
         when(result) {
             is Success -> when(result.status) {
-                is Passed.Succeeded  -> println(result.msg)
-                is Passed.Pending    -> println(result.msg)
+                is Passed.Succeeded  -> println(result.desc)
+                is Passed.Pending    -> println(result.desc)
             }
             is Failure -> when(result.status) {
-                is Failed.Denied     -> println(result.msg)
-                is Failed.Invalid    -> println(result.msg)
-                is Failed.Ignored    -> println(result.msg)
-                is Failed.Errored    -> println(result.msg)
-                is Failed.Unknown -> println(result.msg)
+                is Failed.Denied     -> println(result.desc)
+                is Failed.Invalid    -> println(result.desc)
+                is Failed.Ignored    -> println(result.desc)
+                is Failed.Errored    -> println(result.desc)
+                is Failed.Unknown -> println(result.desc)
             }
         }
 
@@ -478,7 +478,7 @@ class Example_Results : Command("results"), OutcomeBuilder {
 
     fun printResult(result: Result<*, *>): Unit {
         println("success: " + result.success)
-        println("message: " + result.msg)
+        println("message: " + result.desc)
         println("code   : " + result.code)
         println()
         println()

--- a/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Results.kt
+++ b/src/lib/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Results.kt
@@ -44,7 +44,7 @@ class Example_Results : Command("results"), OutcomeBuilder {
         // Properties
         println(start.success)     // true
         println(start.status.code) // Codes.SUCCESS.code
-        println(start.status.msg)  // Codes.SUCCESS.msg
+        println(start.status.desc)  // Codes.SUCCESS.msg
 
         // Safely operate on values with map/flatMap
         val addResult = start.map { it + 1 }
@@ -329,7 +329,7 @@ class Example_Results : Command("results"), OutcomeBuilder {
         // Properties
         println(result.success)     // true
         println(result.status.code) // Codes.SUCCESS.code
-        println(result.status.msg)  // Codes.SUCCESS.msg
+        println(result.status.desc)  // Codes.SUCCESS.msg
 
         // Get value or default to null
         val value1: Int? = result.getOrNull()

--- a/src/lib/kotlin/slatekit-integration/src/main/kotlin/slatekit/integration/apis/CliApi.kt
+++ b/src/lib/kotlin/slatekit-integration/src/main/kotlin/slatekit/integration/apis/CliApi.kt
@@ -26,7 +26,6 @@ import slatekit.context.Context
 import slatekit.results.Codes
 import slatekit.results.Success
 import slatekit.results.Try
-import slatekit.results.builders.Tries
 
 /**
  * Layer on top of the core CliService to provide support for handling command line requests
@@ -73,7 +72,7 @@ open class CliApi(
         val helpCheck = checkForHelp(request)
         return if(helpCheck.first) {
             showHelpFor(request, helpCheck.second)
-            Success(CliResponse(request, true, Codes.HELP.code, mapOf(), args.line), Codes.HELP)
+            Success(CliResponse(request, true, Codes.HELP.name, Codes.HELP.code, mapOf(), args.line), Codes.HELP)
         }
         else {
             // Supply the api-key into each command.
@@ -85,10 +84,11 @@ open class CliApi(
             val cliResponse = CliResponse(
                     requestWithMeta,
                     response.success,
+                    response.name,
                     response.code,
                     response.meta,
                     response.value,
-                    response.msg,
+                    response.desc,
                     response.err,
                     response.tag
             )

--- a/src/lib/kotlin/slatekit-integration/src/main/kotlin/slatekit/integration/apis/FilesApi.kt
+++ b/src/lib/kotlin/slatekit-integration/src/main/kotlin/slatekit/integration/apis/FilesApi.kt
@@ -99,6 +99,6 @@ class FilesApi(val files: CloudFiles, override val context: Context) : slatekit.
                     "CONTENT: " + text
         } else
             "PATH   : " + path
-        return result.fold( { Success(output) }, { Failure(result.msg) }).toTry()
+        return result.fold( { Success(output) }, { Failure(result.desc) }).toTry()
     }
 }

--- a/src/lib/kotlin/slatekit-integration/src/main/kotlin/slatekit/integration/apis/ModuleApi.kt
+++ b/src/lib/kotlin/slatekit-integration/src/main/kotlin/slatekit/integration/apis/ModuleApi.kt
@@ -89,7 +89,7 @@ class ModuleApi(val ctx: slatekit.integration.mods.ModuleContext, override val c
         val all = _items.all().map { it.info.name }
         val results = all.map { name -> uninstallByName(name) }
         val success = results.foldRight(true, { res, acc -> if (!res.success) false else acc })
-        val message = results.map({ result -> if (result.success) "" else result.msg }).joinToString { newline }
+        val message = results.map({ result -> if (result.success) "" else result.desc }).joinToString { newline }
         val result = if (success) Success("Uninstalled all") else Failure(Exception(message))
         return result
     }

--- a/src/lib/kotlin/slatekit-integration/src/main/kotlin/slatekit/integration/mods/Module.kt
+++ b/src/lib/kotlin/slatekit-integration/src/main/kotlin/slatekit/integration/mods/Module.kt
@@ -40,7 +40,7 @@ abstract class Module(
             info.models?.let { models ->
                 val results = models.map { modCtx.setup.install(it, info.version, "", "") }
                 val success = results.all { it.success }
-                val messages = results.map { it.msg }
+                val messages = results.map { it.desc }
                 val message = if (success) "" else messages.joinToString(newline)
                 if (success) Success(message, msg = "") else Failure(Exception(message), msg = message)
             } ?: Failure(Exception(this.info.name + " has no models"))
@@ -57,7 +57,7 @@ abstract class Module(
             info.models?.let { models ->
                 val results = models.map { modCtx.setup.uinstall(it) }
                 val success = results.all { it.success }
-                val messages = results.map { it.msg }
+                val messages = results.map { it.desc }
                 val message = if (success) "" else messages.joinToString(newline)
                 if (success) Success(message, msg = "") else Failure(Exception(message), msg = message)
             } ?: Failure(Exception(this.info.name + " has no models"))
@@ -77,7 +77,7 @@ abstract class Module(
             info.models?.let { models ->
                 models.map { modelName ->
                     val result = modCtx.setup.generateSql(modelName, info.version)
-                    result.msg ?: modelName
+                    result.desc ?: modelName
                 }
             } ?: listOf<String>()
         } else

--- a/src/lib/kotlin/slatekit-notifications/src/main/kotlin/slatekit/notifications/sms/SmsService.kt
+++ b/src/lib/kotlin/slatekit-notifications/src/main/kotlin/slatekit/notifications/sms/SmsService.kt
@@ -71,7 +71,7 @@ abstract class SmsService(
 
         // Case 1: Invalid params
         return if (!result.success) {
-            Failure(result.msg)
+            Failure(result.desc)
         }
         // Case 2: Invalid iso or unsupported
         else if (!countryLookup.contains(finalIso)) {

--- a/src/lib/kotlin/slatekit-notifications/src/main/kotlin/slatekit/notifications/sms/TwilioSms.kt
+++ b/src/lib/kotlin/slatekit-notifications/src/main/kotlin/slatekit/notifications/sms/TwilioSms.kt
@@ -95,7 +95,7 @@ class TwilioSms(
                 )
                 Success(request)
             }
-            is Failure -> Outcomes.errored(phoneResult.msg)
+            is Failure -> Outcomes.errored(phoneResult.desc)
         }
     }
 

--- a/src/lib/kotlin/slatekit-orm/src/main/kotlin/slatekit/orm/migrations/MigrationService.kt
+++ b/src/lib/kotlin/slatekit-orm/src/main/kotlin/slatekit/orm/migrations/MigrationService.kt
@@ -120,7 +120,7 @@ class MigrationService(
         }
         val succeeded = results.filter { it.success }
         val allSql = succeeded.fold("") { acc, result ->
-            acc + newline + "-- ${result.msg}" + newline + result.getOrElse { "Error generating sql" }
+            acc + newline + "-- ${result.desc}" + newline + result.getOrElse { "Error generating sql" }
         }
         val finalFileName = "$fileName.sql"
         val filePath = folders?.let {
@@ -141,7 +141,7 @@ class MigrationService(
         }
         val succeeded = results.filter { it.success }
         val allSql = succeeded.fold("") { acc, result ->
-            acc + newline + "-- ${result.msg}" + newline + result.getOrElse { "Error generating sql" }
+            acc + newline + "-- ${result.desc}" + newline + result.getOrElse { "Error generating sql" }
         }
         val finalFileName = "$fileName.sql"
         val filePath = folders?.let {
@@ -226,7 +226,7 @@ class MigrationService(
     private fun each(operation: (EntityContext) -> Try<String>): Try<List<String>> {
         val results = entities.getEntities().map { operation(it ) }
         val success = results.all { it.success }
-        val messages = results.map { it.msg ?: "" }
+        val messages = results.map { it.desc ?: "" }
         val error = if (success) "" else messages.joinToString(newline)
         return if (success) slatekit.results.Success(messages, msg = "") else slatekit.results.Failure(Exception(error), msg = error)
     }

--- a/src/lib/kotlin/slatekit-policy/src/main/kotlin/slatekit/policy/common/FunctionResult.kt
+++ b/src/lib/kotlin/slatekit-policy/src/main/kotlin/slatekit/policy/common/FunctionResult.kt
@@ -20,7 +20,7 @@ interface FunctionResult {
     val ended: DateTime
 
     val success: Boolean get() { return result.success }
-    val message: String get() { return result.msg }
+    val message: String get() { return result.desc }
     val value: Any? get() { return result.getOrNull() }
 
     fun duration(): Duration { return ended.durationFrom(started) }

--- a/src/lib/kotlin/slatekit-policy/src/main/kotlin/slatekit/policy/common/FunctionState.kt
+++ b/src/lib/kotlin/slatekit-policy/src/main/kotlin/slatekit/policy/common/FunctionState.kt
@@ -26,7 +26,7 @@ interface FunctionState<out T> where T : FunctionResult {
     /**
      * The last message from the result
      */
-    fun msg(): String = lastResult?.msg ?: ""
+    fun msg(): String = lastResult?.desc ?: ""
 
     /**
      * Whether or not the function has been run

--- a/src/lib/kotlin/slatekit-policy/src/main/kotlin/slatekit/policy/policies/Ratio.kt
+++ b/src/lib/kotlin/slatekit-policy/src/main/kotlin/slatekit/policy/policies/Ratio.kt
@@ -30,7 +30,7 @@ class Ratio<I, O>(val limit: Double, val status: Status, val stats: (I) -> Count
             is Failed.Unknown -> isAtThreshold(counts.totalUnexpected(), counts.totalProcessed())
             else -> isAtThreshold(counts.totalUnexpected(), counts.totalProcessed())
         }
-        logger?.info("RATIO: status = ${result.status.msg}")
+        logger?.info("RATIO: status = ${result.status.desc}")
         return if (isMatch) {
             Outcomes.errored(Codes.LIMITED)
         } else {

--- a/src/lib/kotlin/slatekit-result/src/main/kotlin/slatekit/results/Codes.kt
+++ b/src/lib/kotlin/slatekit-result/src/main/kotlin/slatekit/results/Codes.kt
@@ -32,49 +32,49 @@ package slatekit.results
 object Codes {
 
     // Success: 200000 + range
-    @JvmField val SUCCESS         = Passed.Succeeded (200001, "Success")
-    @JvmField val CREATED         = Passed.Succeeded (200002, "Created")
-    @JvmField val UPDATED         = Passed.Succeeded (200003, "Updated")
-    @JvmField val FETCHED         = Passed.Succeeded (200004, "Fetched")
-    @JvmField val PATCHED         = Passed.Succeeded (200005, "Patched")         // E.g. Update a small subset of info
-    @JvmField val DELETED         = Passed.Succeeded (200006, "Deleted")
-    @JvmField val HANDLED         = Passed.Succeeded (200007, "Handled")         // E.g. A silent ok ( similar to http 204 )
-    @JvmField val PENDING         = Passed.Pending   (200008, "Pending")
-    @JvmField val QUEUED          = Passed.Pending   (200009, "Queued" )
-    @JvmField val CONFIRM         = Passed.Pending   (200010, "Confirm")
+    @JvmField val SUCCESS         = Passed.Succeeded ("SUCCESS", 200001, "Success")
+    @JvmField val CREATED         = Passed.Succeeded ("CREATED", 200002, "Created")
+    @JvmField val UPDATED         = Passed.Succeeded ("UPDATED", 200003, "Updated")
+    @JvmField val FETCHED         = Passed.Succeeded ("FETCHED", 200004, "Fetched")
+    @JvmField val PATCHED         = Passed.Succeeded ("PATCHED", 200005, "Patched")         // E.g. Update a small subset of info
+    @JvmField val DELETED         = Passed.Succeeded ("DELETED", 200006, "Deleted")
+    @JvmField val HANDLED         = Passed.Succeeded ("HANDLED", 200007, "Handled")         // E.g. A silent ok ( similar to http 204 )
+    @JvmField val PENDING         = Passed.Pending   ("PENDING", 200008, "Pending")
+    @JvmField val QUEUED          = Passed.Pending   ("QUEUED" , 200009, "Queued" )
+    @JvmField val CONFIRM         = Passed.Pending   ("CONFIRM", 200010, "Confirm")
 
 
     // Invalid: 400000 + range
-    @JvmField val IGNORED         = Failed.Ignored   (400001, "Ignored")         // E.g. Ignored, not exactly an error
-    @JvmField val BAD_REQUEST     = Failed.Invalid   (400002, "Bad Request")     // E.g. Invalid JSON
-    @JvmField val INVALID         = Failed.Invalid   (400003, "Invalid")         // E.g. Valid   JSON but invalid values
+    @JvmField val IGNORED         = Failed.Ignored   ("IGNORED"    , 400001, "Ignored")         // E.g. Ignored, not exactly an error
+    @JvmField val BAD_REQUEST     = Failed.Invalid   ("BAD_REQUEST", 400002, "Bad Request")     // E.g. Invalid JSON
+    @JvmField val INVALID         = Failed.Invalid   ("INVALID"    , 400003, "Invalid")         // E.g. Valid   JSON but invalid values
 
     // Security related
-    @JvmField val DENIED          = Failed.Denied    (400004, "Denied")          // Presumes a checked condition
-    @JvmField val UNSUPPORTED     = Failed.Denied    (400005, "Not supported")   // Presumes a checked condition
-    @JvmField val UNIMPLEMENTED   = Failed.Denied    (400006, "Not implemented") // Presumes a checked condition
-    @JvmField val UNAVAILABLE     = Failed.Denied    (400007, "Not available")   // Presumes a checked condition
-    @JvmField val UNAUTHENTICATED = Failed.Denied    (400008, "Unauthenticated") // Presumes a checked condition
-    @JvmField val UNAUTHORIZED    = Failed.Denied    (400009, "Unauthorized")    // Presumes a checked condition
+    @JvmField val DENIED          = Failed.Denied    ("DENIED"         ,400004, "Denied")          // Presumes a checked condition
+    @JvmField val UNSUPPORTED     = Failed.Denied    ("UNSUPPORTED"    ,400005, "Not supported")   // Presumes a checked condition
+    @JvmField val UNIMPLEMENTED   = Failed.Denied    ("UNIMPLEMENTED"  ,400006, "Not implemented") // Presumes a checked condition
+    @JvmField val UNAVAILABLE     = Failed.Denied    ("UNAVAILABLE"    ,400007, "Not available")   // Presumes a checked condition
+    @JvmField val UNAUTHENTICATED = Failed.Denied    ("UNAUTHENTICATED",400008, "Unauthenticated") // Presumes a checked condition
+    @JvmField val UNAUTHORIZED    = Failed.Denied    ("UNAUTHORIZED"   ,400009, "Unauthorized")    // Presumes a checked condition
 
     // Expected errors: 500000 + range
-    @JvmField val NOT_FOUND       = Failed.Errored   (500001, "Not found")       // E.g. Resource/End point not found
-    @JvmField val MISSING         = Failed.Errored   (500002, "Missing item")    // E.g. Domain model not found
-    @JvmField val FORBIDDEN       = Failed.Errored   (500003, "Forbidden")
-    @JvmField val CONFLICT        = Failed.Errored   (500004, "Conflict")
-    @JvmField val DEPRECATED      = Failed.Errored   (500005, "Deprecated")
-    @JvmField val TIMEOUT         = Failed.Errored   (500006, "Timeout")
-    @JvmField val ERRORED         = Failed.Errored   (500007, "Errored")         // General purpose use
-    @JvmField val LIMITED         = Failed.Errored   (500009, "Limited")
+    @JvmField val NOT_FOUND       = Failed.Errored   ("NOT_FOUND" ,500001, "Not found")       // E.g. Resource/End point not found
+    @JvmField val MISSING         = Failed.Errored   ("MISSING"   ,500002, "Missing item")    // E.g. Domain model not found
+    @JvmField val FORBIDDEN       = Failed.Errored   ("FORBIDDEN" ,500003, "Forbidden")
+    @JvmField val CONFLICT        = Failed.Errored   ("CONFLICT"  ,500004, "Conflict")
+    @JvmField val DEPRECATED      = Failed.Errored   ("DEPRECATED",500005, "Deprecated")
+    @JvmField val TIMEOUT         = Failed.Errored   ("TIMEOUT"   ,500006, "Timeout")
+    @JvmField val ERRORED         = Failed.Errored   ("ERRORED"   ,500007, "Errored")         // General purpose use
+    @JvmField val LIMITED         = Failed.Errored   ("LIMITED"   ,500009, "Limited")
 
     // Unexpected
-    @JvmField val UNEXPECTED      = Failed.Unknown(500008, "Unexpected")
+    @JvmField val UNEXPECTED      = Failed.Unknown("UNEXPECTED",500008, "Unexpected")
 
     // Success ( Interactive / Metadata )
-    @JvmField val EXIT            = Passed.Succeeded (600002, "Exiting")
-    @JvmField val HELP            = Passed.Succeeded (600003, "Help")
-    @JvmField val ABOUT           = Passed.Succeeded (600004, "About")
-    @JvmField val VERSION         = Passed.Succeeded (600005, "Version")
+    @JvmField val EXIT            = Passed.Succeeded ("EXIT"   , 600002, "Exiting")
+    @JvmField val HELP            = Passed.Succeeded ("HELP"   , 600003, "Help")
+    @JvmField val ABOUT           = Passed.Succeeded ("ABOUT"  , 600004, "About")
+    @JvmField val VERSION         = Passed.Succeeded ("VERSION", 600005, "Version")
 
 
     private val mappings = listOf(
@@ -152,10 +152,10 @@ object Codes {
                 info?.second ?: BAD_REQUEST
             }
             else -> when {
-                code in 1..999 -> Passed.Succeeded(code, SUCCESS.msg)
-                code in 2000..2999 -> Failed.Invalid(code, INVALID.msg)
-                code >= 3000 -> Failed.Errored(code, ERRORED.msg)
-                else -> Failed.Errored(code, "Unexpected")
+                code in 1..999 -> Passed.Succeeded(SUCCESS.name, code, SUCCESS.desc)
+                code in 2000..2999 -> Failed.Invalid(INVALID.name, code, INVALID.desc)
+                code >= 3000 -> Failed.Errored(ERRORED.name, code, ERRORED.desc)
+                else -> Failed.Errored(UNEXPECTED.name, code, "Unexpected")
             }
         }
     }

--- a/src/lib/kotlin/slatekit-result/src/main/kotlin/slatekit/results/Err.kt
+++ b/src/lib/kotlin/slatekit-result/src/main/kotlin/slatekit/results/Err.kt
@@ -74,7 +74,7 @@ sealed class Err {
 
         @JvmStatic
         fun code(status: Status): Err {
-            return ErrorInfo(status.msg)
+            return ErrorInfo(status.desc)
         }
 
         @JvmStatic
@@ -85,7 +85,7 @@ sealed class Err {
         @JvmStatic
         fun build(error: Any?): Err {
             return when (error) {
-                null -> Err.of(Codes.UNEXPECTED.msg)
+                null -> Err.of(Codes.UNEXPECTED.desc)
                 is Err -> error
                 is String -> Err.of(error)
                 is Exception -> Err.ex(error)

--- a/src/lib/kotlin/slatekit-result/src/main/kotlin/slatekit/results/Result.kt
+++ b/src/lib/kotlin/slatekit-result/src/main/kotlin/slatekit/results/Result.kt
@@ -47,7 +47,7 @@ sealed class Result<out T, out E> {
      */
     val success: Boolean get() = this is Success
     val code: Int get() = status.code
-    val msg: String get() = status.desc
+    val desc: String get() = status.desc
 
     /**
      * Applies supplied function `f` if this is a [Success]

--- a/src/lib/kotlin/slatekit-result/src/main/kotlin/slatekit/results/Result.kt
+++ b/src/lib/kotlin/slatekit-result/src/main/kotlin/slatekit/results/Result.kt
@@ -47,7 +47,7 @@ sealed class Result<out T, out E> {
      */
     val success: Boolean get() = this is Success
     val code: Int get() = status.code
-    val msg: String get() = status.msg
+    val msg: String get() = status.desc
 
     /**
      * Applies supplied function `f` if this is a [Success]
@@ -247,7 +247,7 @@ sealed class Result<out T, out E> {
         is Success -> this
         is Failure -> {
             val err = when (this.error) {
-                null -> Err.of(Codes.UNEXPECTED.msg)
+                null -> Err.of(Codes.UNEXPECTED.desc)
                 is Err -> error
                 is String -> Err.of(error)
                 is Exception -> Err.ex(error)
@@ -276,7 +276,7 @@ sealed class Result<out T, out E> {
             when (this.error) {
                 is Exception -> this as Try<T>
                 is Err -> Failure(ExceptionErr(this.error.toString(), this.error), this.status)
-                null -> Failure(Exception(this.status.msg), this.status)
+                null -> Failure(Exception(this.status.desc), this.status)
                 else -> Failure(Exception(this.error.toString()), this.status)
             }
         }

--- a/src/lib/kotlin/slatekit-result/src/main/kotlin/slatekit/results/Status.kt
+++ b/src/lib/kotlin/slatekit-result/src/main/kotlin/slatekit/results/Status.kt
@@ -16,17 +16,29 @@ package slatekit.results
 
 
 /**
- * Interface to represent a Status with both an integer code and descriptive message
+ * Interface to represent a Status with both an integer code and description
  * @sample :
- * { code: 8000, msg: "Invalid request" }
- * { code: 8001, msg: "Unauthorized"    }
+ * { name: "INVALID"     , code: 400000, msg: "Invalid request" }
+ * { name: "UNAUTHORIZED", code: 400001, msg: "Unauthorized"    }
  *
  */
 interface Status {
-    val code:Int
-    val msg: String
+    /**
+     * Used as short user-friendly enum e.g. "INVALID", "UNAUTHORIZED"
+     */
+    val name:String
 
-    fun copyMsg(msg: String): Status
+    /**
+     * Used as a generic application code that can be converted to other codes such as HTTP.
+     */
+    val code:Int
+
+    /**
+     * Description for status
+     */
+    val desc: String
+
+    fun copyDesc(msg: String): Status
     fun copyAll(msg: String, code: Int): Status
 
     companion object {
@@ -39,8 +51,8 @@ interface Status {
             // of [Status] if the msg/code are empty and or they are the same as Success.
             if (code == null && msg == null || msg == "") return defaultStatus
             if (code == defaultStatus.code && msg == null) return defaultStatus
-            if (code == defaultStatus.code && msg == defaultStatus.msg) return defaultStatus
-            return defaultStatus.copyAll(msg ?: defaultStatus.msg, code ?: defaultStatus.code) as T
+            if (code == defaultStatus.code && msg == defaultStatus.desc) return defaultStatus
+            return defaultStatus.copyAll(msg ?: defaultStatus.desc, code ?: defaultStatus.code) as T
         }
 
         /**
@@ -51,8 +63,8 @@ interface Status {
             // of [Status] if the msg/code are empty and or they are the same as Success.
             if (msg == null && rawStatus == null) return status
             if (msg == null && rawStatus != null) return rawStatus
-            if (msg != null && rawStatus == null) return status.copyMsg(msg) as T
-            if (msg != null && rawStatus != null) return rawStatus.copyMsg(msg) as T
+            if (msg != null && rawStatus == null) return status.copyDesc(msg) as T
+            if (msg != null && rawStatus != null) return rawStatus.copyDesc(msg) as T
             return status
         }
     }
@@ -63,20 +75,20 @@ interface Status {
  * Sum Type to represent the different possible Statuses that can be supplied to the @see[Success]
  */
 sealed class Passed : Status {
-    data class Succeeded (override val code: Int, override val msg: String) : Passed()
-    data class Pending   (override val code: Int, override val msg: String) : Passed()
+    data class Succeeded (override val name:String, override val code: Int, override val desc: String) : Passed()
+    data class Pending   (override val name:String, override val code: Int, override val desc: String) : Passed()
 
     override fun copyAll(msg: String, code: Int): Status {
         return when (this) {
-            is Succeeded -> this.copy(code = code, msg = msg)
-            is Pending -> this.copy(code = code, msg = msg)
+            is Succeeded -> this.copy(code = code, desc = msg)
+            is Pending -> this.copy(code = code, desc = msg)
         }
     }
 
-    override fun copyMsg(msg: String): Status {
+    override fun copyDesc(msg: String): Status {
         return when (this) {
-            is Succeeded -> this.copy(msg = msg)
-            is Pending -> this.copy(msg = msg)
+            is Succeeded -> this.copy(desc = msg)
+            is Pending -> this.copy(desc = msg)
         }
     }
 }
@@ -86,30 +98,30 @@ sealed class Passed : Status {
  * Sum Type to represent the different possible Statuses that can be supplied to the @see[Failure]
  */
 sealed class Failed : Status {
-    data class Denied    (override val code: Int, override val msg: String) : Failed() // Security related
-    data class Ignored   (override val code: Int, override val msg: String) : Failed() // Ignored for processing
-    data class Invalid   (override val code: Int, override val msg: String) : Failed() // Bad inputs
-    data class Errored   (override val code: Int, override val msg: String) : Failed() // Expected failures
-    data class Unknown   (override val code: Int, override val msg: String) : Failed() // Unexpected failures
+    data class Denied    (override val name:String, override val code: Int, override val desc: String) : Failed() // Security related
+    data class Ignored   (override val name:String, override val code: Int, override val desc: String) : Failed() // Ignored for processing
+    data class Invalid   (override val name:String, override val code: Int, override val desc: String) : Failed() // Bad inputs
+    data class Errored   (override val name:String, override val code: Int, override val desc: String) : Failed() // Expected failures
+    data class Unknown   (override val name:String, override val code: Int, override val desc: String) : Failed() // Unexpected failures
 
 
     override fun copyAll(msg: String, code: Int): Status {
         return when (this) {
-            is Denied  -> this.copy(code = code, msg = msg)
-            is Invalid -> this.copy(code = code, msg = msg)
-            is Ignored -> this.copy(code = code, msg = msg)
-            is Errored -> this.copy(code = code, msg = msg)
-            is Unknown -> this.copy(code = code, msg = msg)
+            is Denied  -> this.copy(name = name, code = code, desc = msg)
+            is Invalid -> this.copy(name = name, code = code, desc = msg)
+            is Ignored -> this.copy(name = name, code = code, desc = msg)
+            is Errored -> this.copy(name = name, code = code, desc = msg)
+            is Unknown -> this.copy(name = name, code = code, desc = msg)
         }
     }
 
-    override fun copyMsg(msg: String): Status {
+    override fun copyDesc(msg: String): Status {
         return when (this) {
-            is Denied -> this.copy(msg = msg)
-            is Invalid -> this.copy(msg = msg)
-            is Ignored -> this.copy(msg = msg)
-            is Errored -> this.copy(msg = msg)
-            is Unknown -> this.copy(msg = msg)
+            is Denied  -> this.copy(desc = msg)
+            is Invalid -> this.copy(desc = msg)
+            is Ignored -> this.copy(desc = msg)
+            is Errored -> this.copy(desc = msg)
+            is Unknown -> this.copy(desc = msg)
         }
     }
 }

--- a/src/lib/kotlin/slatekit-result/src/main/kotlin/slatekit/results/builders/Notices.kt
+++ b/src/lib/kotlin/slatekit-result/src/main/kotlin/slatekit/results/builders/Notices.kt
@@ -18,8 +18,8 @@ import slatekit.results.*
  * Builds [Result] with [Failure] error type of [String]
  */
 interface NoticeBuilder : Builder<String> {
-    override fun errorFromEx(ex: Exception, defaultStatus: Status): String = ex.message ?: defaultStatus.msg
-    override fun errorFromStr(msg: String?, defaultStatus: Status): String = msg ?: defaultStatus.msg
+    override fun errorFromEx(ex: Exception, defaultStatus: Status): String = ex.message ?: defaultStatus.desc
+    override fun errorFromStr(msg: String?, defaultStatus: Status): String = msg ?: defaultStatus.desc
     override fun errorFromErr(err: Err, defaultStatus: Status): String = err.toString()
 }
 
@@ -31,7 +31,7 @@ object Notices : NoticeBuilder {
      * Build a Notice<T> ( type alias ) for Result<T,String> using the supplied function
      */
     @JvmStatic
-    inline fun <T> of(f: () -> T): Notice<T> = build(f, { e -> e.message ?: Codes.ERRORED.msg })
+    inline fun <T> of(f: () -> T): Notice<T> = build(f, { e -> e.message ?: Codes.ERRORED.desc })
 
     /**
      * Build a Result<T,E> using the supplied callback and error handler

--- a/src/lib/kotlin/slatekit-result/src/main/kotlin/slatekit/results/builders/Outcomes.kt
+++ b/src/lib/kotlin/slatekit-result/src/main/kotlin/slatekit/results/builders/Outcomes.kt
@@ -19,7 +19,7 @@ import slatekit.results.*
  */
 interface OutcomeBuilder : Builder<Err> {
     override fun errorFromEx(ex: Exception, defaultStatus: Status): Err = Err.ex(ex)
-    override fun errorFromStr(msg: String?, defaultStatus: Status): Err = Err.of(msg ?: defaultStatus.msg)
+    override fun errorFromStr(msg: String?, defaultStatus: Status): Err = Err.of(msg ?: defaultStatus.desc)
     override fun errorFromErr(err: Err, defaultStatus: Status): Err = err
 }
 

--- a/src/lib/kotlin/slatekit-result/src/main/kotlin/slatekit/results/builders/Tries.kt
+++ b/src/lib/kotlin/slatekit-result/src/main/kotlin/slatekit/results/builders/Tries.kt
@@ -22,7 +22,6 @@ import slatekit.results.IgnoredException
 import slatekit.results.InvalidException
 import slatekit.results.Result
 import slatekit.results.Status
-import slatekit.results.StatusException
 import slatekit.results.Success
 import slatekit.results.Try
 import slatekit.results.UnexpectedException
@@ -32,8 +31,8 @@ import slatekit.results.UnexpectedException
  */
 interface TryBuilder : Builder<Exception> {
     override fun errorFromEx(ex: Exception, defaultStatus: Status): Exception = ex
-    override fun errorFromStr(msg: String?, defaultStatus: Status): Exception = Exception(msg ?: defaultStatus.msg)
-    override fun errorFromErr(err: Err, defaultStatus: Status): Exception = ExceptionErr(defaultStatus.msg, err)
+    override fun errorFromStr(msg: String?, defaultStatus: Status): Exception = Exception(msg ?: defaultStatus.desc)
+    override fun errorFromErr(err: Err, defaultStatus: Status): Exception = ExceptionErr(defaultStatus.desc, err)
 }
 
 /**

--- a/src/lib/kotlin/slatekit-server/src/main/kotlin/slatekit/server/common/ServerDiagnostics.kt
+++ b/src/lib/kotlin/slatekit-server/src/main/kotlin/slatekit/server/common/ServerDiagnostics.kt
@@ -32,7 +32,7 @@ class ServerDiagnostics(override val source: String,
      * Record all relevant diagnostics
      */
     private fun log(sender: Any, request: Request, response: Response<*>) {
-        val msg = response.msg ?: ""
+        val msg = response.desc ?: ""
         when {
             response.isInSuccessRange()    -> logger?.info ("$source succeeded: $msg")
             response.isFilteredOut()       -> logger?.info ("$source filtered : $msg")
@@ -47,7 +47,7 @@ class ServerDiagnostics(override val source: String,
      * Record all relevant diagnostics
      */
     private fun meter(sender: Any, request: Request, response: Response<*>) {
-        val msg = response.msg ?: ""
+        val msg = response.desc ?: ""
         when {
             response.isInSuccessRange()    -> metrics?.count("$source.total_successes", tags)
             response.isFilteredOut()       -> metrics?.count("$source.total_filtered", tags)

--- a/src/lib/kotlin/slatekit-server/src/main/kotlin/slatekit/server/ktor/KtorResponse.kt
+++ b/src/lib/kotlin/slatekit-server/src/main/kotlin/slatekit/server/ktor/KtorResponse.kt
@@ -87,7 +87,7 @@ class KtorResponse  : ResponseHandler {
 
     override fun toHttpStatus(response:Response<Any>): HttpStatusCode {
         val http = Codes.toHttp(Passed.Succeeded(response.code, response.msg ?: ""))
-        return HttpStatusCode(http.first, http.second.msg)
+        return HttpStatusCode(http.first, http.second.desc)
     }
 
 

--- a/src/lib/kotlin/slatekit-server/src/main/kotlin/slatekit/server/ktor/KtorResponse.kt
+++ b/src/lib/kotlin/slatekit-server/src/main/kotlin/slatekit/server/ktor/KtorResponse.kt
@@ -86,7 +86,7 @@ class KtorResponse  : ResponseHandler {
 
 
     override fun toHttpStatus(response:Response<Any>): HttpStatusCode {
-        val http = Codes.toHttp(Passed.Succeeded(response.code, response.msg ?: ""))
+        val http = Codes.toHttp(Passed.Succeeded(response.name, response.code, response.desc ?: ""))
         return HttpStatusCode(http.first, http.second.desc)
     }
 

--- a/src/lib/kotlin/slatekit-tests/src/test/java/results/StatusTestsJava.java
+++ b/src/lib/kotlin/slatekit-tests/src/test/java/results/StatusTestsJava.java
@@ -33,6 +33,6 @@ public class StatusTestsJava {
 
     private void checkCode(Status status, int expectedCode, String expectedMsg){
         Assert.assertEquals(status.getCode(), expectedCode);
-        Assert.assertEquals(status.getMsg(), expectedMsg);
+        Assert.assertEquals(status.getDesc(), expectedMsg);
     }
 }

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/apis/ApiTestsBase.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/apis/ApiTestsBase.kt
@@ -120,7 +120,7 @@ open class ApiTestsBase {
 
         Assert.assertTrue(actual.code == expected.code)
         Assert.assertTrue(actual.success == expected.success)
-        Assert.assertTrue(actual.msg == expected.msg)
+        Assert.assertTrue(actual.desc == expected.desc)
     }
 
 
@@ -156,7 +156,7 @@ open class ApiTestsBase {
         // Compare here.
         Assert.assertTrue(actual.code == response.code)
         Assert.assertTrue(actual.success == response.success)
-        Assert.assertTrue(actual.msg == response.msg)
+        Assert.assertTrue(actual.desc == response.desc)
         actual.onSuccess {
             Assert.assertTrue(it == response.value)
         }

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/apis/Api_MIddleware_Tests.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/apis/Api_MIddleware_Tests.kt
@@ -61,7 +61,7 @@ class Api_Middleware_Tests : ApiTestsBase() {
 
         Assert.assertTrue(!r1.success)
         Assert.assertTrue(r1.code == Codes.ERRORED.code)
-        Assert.assertTrue(r1.msg == Codes.ERRORED.desc)
+        Assert.assertTrue(r1.desc == Codes.ERRORED.desc)
     }
 
 
@@ -72,7 +72,7 @@ class Api_Middleware_Tests : ApiTestsBase() {
 
         Assert.assertTrue(!r1.success)
         Assert.assertTrue(r1.code == Codes.UNEXPECTED.code)
-        Assert.assertTrue(r1.msg == Codes.UNEXPECTED.desc)
+        Assert.assertTrue(r1.desc == Codes.UNEXPECTED.desc)
         Assert.assertTrue(api.onErrorHookCount.size == 1)
     }
 
@@ -84,7 +84,7 @@ class Api_Middleware_Tests : ApiTestsBase() {
 
         Assert.assertTrue(!r1.success)
         Assert.assertTrue(r1.code == Codes.ERRORED.code)
-        Assert.assertTrue(r1.msg == Codes.ERRORED.desc)
+        Assert.assertTrue(r1.desc == Codes.ERRORED.desc)
         Assert.assertTrue(api.onErrorHookCount.size == 1)
     }
 }

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/apis/Api_MIddleware_Tests.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/apis/Api_MIddleware_Tests.kt
@@ -61,7 +61,7 @@ class Api_Middleware_Tests : ApiTestsBase() {
 
         Assert.assertTrue(!r1.success)
         Assert.assertTrue(r1.code == Codes.ERRORED.code)
-        Assert.assertTrue(r1.msg == Codes.ERRORED.msg)
+        Assert.assertTrue(r1.msg == Codes.ERRORED.desc)
     }
 
 
@@ -72,7 +72,7 @@ class Api_Middleware_Tests : ApiTestsBase() {
 
         Assert.assertTrue(!r1.success)
         Assert.assertTrue(r1.code == Codes.UNEXPECTED.code)
-        Assert.assertTrue(r1.msg == Codes.UNEXPECTED.msg)
+        Assert.assertTrue(r1.msg == Codes.UNEXPECTED.desc)
         Assert.assertTrue(api.onErrorHookCount.size == 1)
     }
 
@@ -84,7 +84,7 @@ class Api_Middleware_Tests : ApiTestsBase() {
 
         Assert.assertTrue(!r1.success)
         Assert.assertTrue(r1.code == Codes.ERRORED.code)
-        Assert.assertTrue(r1.msg == Codes.ERRORED.msg)
+        Assert.assertTrue(r1.msg == Codes.ERRORED.desc)
         Assert.assertTrue(api.onErrorHookCount.size == 1)
     }
 }

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/app/AppLoaderTests.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/app/AppLoaderTests.kt
@@ -23,7 +23,6 @@ import slatekit.app.AppRunner
 import slatekit.results.Status
 import slatekit.results.Codes
 import slatekit.results.Success
-import slatekit.results.Try
 
 
 class AppLoaderTests  {
@@ -78,7 +77,7 @@ class AppLoaderTests  {
 
             Assert.assertEquals(true, result.success)
             Assert.assertEquals(status.code, result.code)
-            Assert.assertEquals(status.msg, result.msg)
+            Assert.assertEquals(status.desc, result.msg)
             val actual = result as Success<ConfigValueTest>
             Assert.assertTrue(value == actual.value)
         }

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/app/AppLoaderTests.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/app/AppLoaderTests.kt
@@ -77,7 +77,7 @@ class AppLoaderTests  {
 
             Assert.assertEquals(true, result.success)
             Assert.assertEquals(status.code, result.code)
-            Assert.assertEquals(status.desc, result.msg)
+            Assert.assertEquals(status.desc, result.desc)
             val actual = result as Success<ConfigValueTest>
             Assert.assertTrue(value == actual.value)
         }

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/cli/CLITests.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/cli/CLITests.kt
@@ -57,7 +57,7 @@ class CLITests {
             val text = args.line
             testExec.add(text)
             val req = CliRequest.build(Args.empty(), text)
-            return Success(CliResponse(req, true, Codes.SUCCESS.code, mapOf(), text))
+            return Success(CliResponse(req, true, Codes.SUCCESS.name, Codes.SUCCESS.code, mapOf(), text))
         }
 
 

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/cli/ShellTests.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/cli/ShellTests.kt
@@ -59,7 +59,7 @@ class ShellTests  {
       val cli = getCli()
       val result = runBlocking { cli.executeText("?") }
       Assert.assertTrue( result.code == Codes.HELP.code )
-      Assert.assertTrue( result.msg  == Codes.HELP.msg)
+      Assert.assertTrue( result.msg  == Codes.HELP.desc)
     }
 
 
@@ -68,7 +68,7 @@ class ShellTests  {
       val result = runBlocking {  cli.executeText("app ?") }
       //Assert.assertTrue( result.getOrElse { null } == null )
       Assert.assertTrue( result.code == Codes.HELP.code )
-      Assert.assertTrue( result.msg  == Codes.HELP.msg)
+      Assert.assertTrue( result.msg  == Codes.HELP.desc)
     }
 
 
@@ -77,7 +77,7 @@ class ShellTests  {
       val result = runBlocking { cli.executeText("app.info ?") }
       //Assert.assertTrue( result.getOrElse { null } == null )
       Assert.assertTrue( result.code == Codes.HELP.code )
-      Assert.assertTrue( result.msg  == Codes.HELP.msg)
+      Assert.assertTrue( result.msg  == Codes.HELP.desc)
     }
 
 
@@ -86,7 +86,7 @@ class ShellTests  {
       val result = runBlocking { cli.executeText("app.version.host ?") }
       //Assert.assertTrue( result.getOrElse { null } == null )
       Assert.assertTrue( result.code == Codes.HELP.code )
-      Assert.assertTrue( result.msg  == Codes.HELP.msg)
+      Assert.assertTrue( result.msg  == Codes.HELP.desc)
     }
 
 

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/cli/ShellTests.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/cli/ShellTests.kt
@@ -43,7 +43,7 @@ class ShellTests  {
       val result = runBlocking { cli.executeText("app.version.host") }
 
       val res = result.getOrElse {
-        CliResponse( CliRequest.build(Args.empty(), ""),true, 1, mapOf(), "" )
+        CliResponse( CliRequest.build(Args.empty(), ""),true, Codes.SUCCESS.name, 1, mapOf(), "" )
       }
       val req = res.request
       Assert.assertTrue( req.area == "app" )
@@ -59,7 +59,7 @@ class ShellTests  {
       val cli = getCli()
       val result = runBlocking { cli.executeText("?") }
       Assert.assertTrue( result.code == Codes.HELP.code )
-      Assert.assertTrue( result.msg  == Codes.HELP.desc)
+      Assert.assertTrue( result.desc  == Codes.HELP.desc)
     }
 
 
@@ -68,7 +68,7 @@ class ShellTests  {
       val result = runBlocking {  cli.executeText("app ?") }
       //Assert.assertTrue( result.getOrElse { null } == null )
       Assert.assertTrue( result.code == Codes.HELP.code )
-      Assert.assertTrue( result.msg  == Codes.HELP.desc)
+      Assert.assertTrue( result.desc  == Codes.HELP.desc)
     }
 
 
@@ -77,7 +77,7 @@ class ShellTests  {
       val result = runBlocking { cli.executeText("app.info ?") }
       //Assert.assertTrue( result.getOrElse { null } == null )
       Assert.assertTrue( result.code == Codes.HELP.code )
-      Assert.assertTrue( result.msg  == Codes.HELP.desc)
+      Assert.assertTrue( result.desc  == Codes.HELP.desc)
     }
 
 
@@ -86,7 +86,7 @@ class ShellTests  {
       val result = runBlocking { cli.executeText("app.version.host ?") }
       //Assert.assertTrue( result.getOrElse { null } == null )
       Assert.assertTrue( result.code == Codes.HELP.code )
-      Assert.assertTrue( result.msg  == Codes.HELP.desc)
+      Assert.assertTrue( result.desc  == Codes.HELP.desc)
     }
 
 

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/core/Commands_Tests.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/core/Commands_Tests.kt
@@ -19,7 +19,6 @@ import slatekit.common.*
 import slatekit.cmds.Command
 import slatekit.cmds.CommandRequest
 import slatekit.cmds.Commands
-import slatekit.common.envs.Env
 import slatekit.common.envs.EnvMode
 import slatekit.results.Success
 import slatekit.results.Try
@@ -203,7 +202,7 @@ class Commands_Tests {
             Assert.assertTrue(it.hasRun())
 //            Assert.assertTrue(it.countFailure() == 1L)
 //            Assert.assertTrue(it.countAttempt() == 1L)
-            Assert.assertTrue(it.lastResult?.msg == "Unexpected")
+            Assert.assertTrue(it.lastResult?.desc == "Unexpected")
             //Assert.assertTrue(it.lastResult?.error()!!.message == "Error while executing : create error. error_1")
             Assert.assertTrue(it.id.name == "create.error")
         }

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/functions/Policy_Tests.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/functions/Policy_Tests.kt
@@ -112,7 +112,7 @@ class Policy_Tests {
     @Test
     fun test_ratio_success(){
         val counts = Counters(Identity.test("policy"))
-        val policy: Policy<String, Int> = Ratio(.4, Failed.Denied(0, ""), { counts })
+        val policy: Policy<String, Int> = Ratio(.4, Failed.Denied(Codes.DENIED.name, 0, ""), { counts })
         val result = runBlocking {
             policy.run("1") { counts.incProcessed(); counts.incSucceeded(); Outcomes.of(it.toInt()) }
             policy.run("2") { counts.incProcessed(); counts.incDenied(); Outcomes.of(it.toInt()) }
@@ -127,7 +127,7 @@ class Policy_Tests {
     @Test
     fun test_ratio_failure(){
         val counts = Counters(Identity.test("policy"))
-        val policy: Policy<String, Int> = Ratio(.5, Failed.Denied(0, ""), { counts })
+        val policy: Policy<String, Int> = Ratio(.5, Failed.Denied(Codes.DENIED.name, 0, ""), { counts })
         val result = runBlocking {
             policy.run("1") { counts.incProcessed(); counts.incSucceeded(); Outcomes.of(it.toInt()) }
             policy.run("2") { counts.incProcessed(); counts.incDenied(); Outcomes.of(it.toInt()) }

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/meta/ReflectorTests.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/meta/ReflectorTests.kt
@@ -217,7 +217,7 @@ class ReflectorTests {
         val result = res as Notice<String>
         val v = result.getOrElse { "" }
         Assert.assertTrue(v == "ok")
-        Assert.assertTrue(result.msg == "activated 123456789, 987, true, 2017-05-27T00:00-04:00[America/New_York]")
+        Assert.assertTrue(result.desc == "activated 123456789, 987, true, 2017-05-27T00:00-04:00[America/New_York]")
     }
 
 

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/results/ResultBuilderTests.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/results/ResultBuilderTests.kt
@@ -40,7 +40,7 @@ class ResultBuilderTests : ResultTestSupport, OutcomeBuilder {
     @Test
     fun can_build_ignored() {
         val status = Codes.IGNORED
-        ensureFailure(ignored<Int>(), status, expectedError = status.msg)
+        ensureFailure(ignored<Int>(), status, expectedError = status.desc)
         ensureFailure(ignored<Int>("ignored-x"), status, expectedError = "ignored-x")
         ensureFailure(ignored<Int>(Exception("ignored-x")), status, expectedError = "ignored-x")
         ensureFailure(ignored<Int>(Err.of("ignored-x")), status, expectedError = "ignored-x")
@@ -50,7 +50,7 @@ class ResultBuilderTests : ResultTestSupport, OutcomeBuilder {
     @Test
     fun can_build_invalid() {
         val status = Codes.INVALID
-        ensureFailure(invalid<Int>(), status, expectedError = status.msg)
+        ensureFailure(invalid<Int>(), status, expectedError = status.desc)
         ensureFailure(invalid<Int>("invalid-x"), status, expectedError = "invalid-x")
         ensureFailure(invalid<Int>(Exception("invalid-x")), status, expectedError = "invalid-x")
         ensureFailure(invalid<Int>(Err.of("invalid-x")), status, expectedError = "invalid-x")
@@ -60,7 +60,7 @@ class ResultBuilderTests : ResultTestSupport, OutcomeBuilder {
     @Test
     fun can_build_denied() {
         val status = Codes.DENIED
-        ensureFailure(denied<Int>(), status, expectedError = status.msg)
+        ensureFailure(denied<Int>(), status, expectedError = status.desc)
         ensureFailure(denied<Int>("denied-x"), status, expectedError = "denied-x")
         ensureFailure(denied<Int>(Exception("denied-x")), status, expectedError = "denied-x")
         ensureFailure(denied<Int>(Err.of("denied-x")), status, expectedError = "denied-x")
@@ -70,7 +70,7 @@ class ResultBuilderTests : ResultTestSupport, OutcomeBuilder {
     @Test
     fun can_build_error() {
         val status = Codes.ERRORED
-        ensureFailure(errored<Int>(), status, expectedError = status.msg)
+        ensureFailure(errored<Int>(), status, expectedError = status.desc)
         ensureFailure(errored<Int>("error-x"), status, expectedError = "error-x")
         ensureFailure(errored<Int>(Exception("error-x")), status, expectedError = "error-x")
         ensureFailure(errored<Int>(Err.of("error-x")), status, expectedError = "error-x")
@@ -80,7 +80,7 @@ class ResultBuilderTests : ResultTestSupport, OutcomeBuilder {
     @Test
     fun can_build_unexpected() {
         val status = Codes.UNEXPECTED
-        ensureFailure(Outcomes.unexpected<Int>(), status, expectedError = status.msg)
+        ensureFailure(Outcomes.unexpected<Int>(), status, expectedError = status.desc)
         ensureFailure(Outcomes.unexpected<Int>("unexpected-x"), status, expectedError = "unexpected-x")
         ensureFailure(Outcomes.unexpected<Int>(Exception("unexpected-x")), status, expectedError = "unexpected-x")
         ensureFailure(Outcomes.unexpected<Int>(Err.of("unexpected-x")), status, expectedError = "unexpected-x")

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/results/ResultFunctionalTests.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/results/ResultFunctionalTests.kt
@@ -100,7 +100,7 @@ class ResultFunctionalTests {
         Assert.assertEquals(false, result2.success)
         Assert.assertEquals(Codes.ERRORED, result2.status)
         Assert.assertEquals(Codes.ERRORED.code, result2.code)
-        Assert.assertEquals(Codes.ERRORED.msg, result2.msg)
+        Assert.assertEquals(Codes.ERRORED.desc, result2.msg)
         Assert.assertEquals("??", result2.getOrElse { "??" })
     }
 
@@ -112,7 +112,7 @@ class ResultFunctionalTests {
         Assert.assertEquals(false, result2.success)
         Assert.assertEquals(Codes.ERRORED, result2.status)
         Assert.assertEquals(Codes.ERRORED.code, result2.code)
-        Assert.assertEquals(Codes.ERRORED.msg, result2.msg)
+        Assert.assertEquals(Codes.ERRORED.desc, result2.msg)
         Assert.assertEquals("??", result2.getOrElse { "??" })
     }
 
@@ -124,7 +124,7 @@ class ResultFunctionalTests {
         Assert.assertEquals(false, result2.success)
         Assert.assertEquals(Codes.ERRORED, result2.status)
         Assert.assertEquals(Codes.ERRORED.code, result2.code)
-        Assert.assertEquals(Codes.ERRORED.msg, result2.msg)
+        Assert.assertEquals(Codes.ERRORED.desc, result2.msg)
         Assert.assertEquals("??", result2.getOrElse { "??" })
     }
 
@@ -136,7 +136,7 @@ class ResultFunctionalTests {
         Assert.assertEquals(false, result2.success)
         Assert.assertEquals(Codes.ERRORED, result2.status)
         Assert.assertEquals(Codes.ERRORED.code, result2.code)
-        Assert.assertEquals(Codes.ERRORED.msg, result2.msg)
+        Assert.assertEquals(Codes.ERRORED.desc, result2.msg)
         result2.onFailure {
             Assert.assertEquals(0, it)
         }
@@ -150,7 +150,7 @@ class ResultFunctionalTests {
         Assert.assertEquals(false, result2.success)
         Assert.assertEquals(Codes.ERRORED, result2.status)
         Assert.assertEquals(Codes.ERRORED.code, result2.code)
-        Assert.assertEquals(Codes.ERRORED.msg, result2.msg)
+        Assert.assertEquals(Codes.ERRORED.desc, result2.msg)
         result2.onFailure {
             Assert.assertEquals(0, it)
         }
@@ -170,7 +170,7 @@ class ResultFunctionalTests {
         Assert.assertEquals(true, r2.success)
         Assert.assertEquals(Codes.SUCCESS, r2.status)
         Assert.assertEquals(Codes.SUCCESS.code, r2.code)
-        Assert.assertEquals(Codes.SUCCESS.msg, r2.msg)
+        Assert.assertEquals(Codes.SUCCESS.desc, r2.msg)
         r2.onSuccess {
             Assert.assertEquals("peter parker : spider-man", it )
         }

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/results/ResultFunctionalTests.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/results/ResultFunctionalTests.kt
@@ -100,7 +100,7 @@ class ResultFunctionalTests {
         Assert.assertEquals(false, result2.success)
         Assert.assertEquals(Codes.ERRORED, result2.status)
         Assert.assertEquals(Codes.ERRORED.code, result2.code)
-        Assert.assertEquals(Codes.ERRORED.desc, result2.msg)
+        Assert.assertEquals(Codes.ERRORED.desc, result2.desc)
         Assert.assertEquals("??", result2.getOrElse { "??" })
     }
 
@@ -112,7 +112,7 @@ class ResultFunctionalTests {
         Assert.assertEquals(false, result2.success)
         Assert.assertEquals(Codes.ERRORED, result2.status)
         Assert.assertEquals(Codes.ERRORED.code, result2.code)
-        Assert.assertEquals(Codes.ERRORED.desc, result2.msg)
+        Assert.assertEquals(Codes.ERRORED.desc, result2.desc)
         Assert.assertEquals("??", result2.getOrElse { "??" })
     }
 
@@ -124,7 +124,7 @@ class ResultFunctionalTests {
         Assert.assertEquals(false, result2.success)
         Assert.assertEquals(Codes.ERRORED, result2.status)
         Assert.assertEquals(Codes.ERRORED.code, result2.code)
-        Assert.assertEquals(Codes.ERRORED.desc, result2.msg)
+        Assert.assertEquals(Codes.ERRORED.desc, result2.desc)
         Assert.assertEquals("??", result2.getOrElse { "??" })
     }
 
@@ -136,7 +136,7 @@ class ResultFunctionalTests {
         Assert.assertEquals(false, result2.success)
         Assert.assertEquals(Codes.ERRORED, result2.status)
         Assert.assertEquals(Codes.ERRORED.code, result2.code)
-        Assert.assertEquals(Codes.ERRORED.desc, result2.msg)
+        Assert.assertEquals(Codes.ERRORED.desc, result2.desc)
         result2.onFailure {
             Assert.assertEquals(0, it)
         }
@@ -150,7 +150,7 @@ class ResultFunctionalTests {
         Assert.assertEquals(false, result2.success)
         Assert.assertEquals(Codes.ERRORED, result2.status)
         Assert.assertEquals(Codes.ERRORED.code, result2.code)
-        Assert.assertEquals(Codes.ERRORED.desc, result2.msg)
+        Assert.assertEquals(Codes.ERRORED.desc, result2.desc)
         result2.onFailure {
             Assert.assertEquals(0, it)
         }
@@ -170,7 +170,7 @@ class ResultFunctionalTests {
         Assert.assertEquals(true, r2.success)
         Assert.assertEquals(Codes.SUCCESS, r2.status)
         Assert.assertEquals(Codes.SUCCESS.code, r2.code)
-        Assert.assertEquals(Codes.SUCCESS.desc, r2.msg)
+        Assert.assertEquals(Codes.SUCCESS.desc, r2.desc)
         r2.onSuccess {
             Assert.assertEquals("peter parker : spider-man", it )
         }

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/results/ResultTestSupport.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/results/ResultTestSupport.kt
@@ -17,7 +17,7 @@ interface ResultTestSupport {
         Assert.assertEquals( result.status.code, (expectedCode ?: expectedStatus.code))
         Assert.assertEquals( result.status.desc , (expectedMessage ?: expectedStatus.desc))
         Assert.assertEquals( result.code , (expectedCode ?: expectedStatus.code))
-        Assert.assertEquals( result.msg , (expectedMessage ?: expectedStatus.desc))
+        Assert.assertEquals( result.desc , (expectedMessage ?: expectedStatus.desc))
 
         result.onSuccess { value ->
             Assert.assertEquals(expectedValue, value)
@@ -36,7 +36,7 @@ interface ResultTestSupport {
         Assert.assertEquals(result.status.code , (expectedStatusCode ?: expectedStatus.code))
         Assert.assertEquals(result.status.desc , (expectedStatusMsg ?: expectedStatus.desc))
         Assert.assertEquals(result.code , (expectedStatusCode ?: expectedStatus.code))
-        Assert.assertEquals(result.msg , (expectedStatusMsg ?: expectedStatus.desc))
+        Assert.assertEquals(result.desc , (expectedStatusMsg ?: expectedStatus.desc))
         result.onFailure {
             when (it) {
                 is String    -> Assert.assertEquals(it , expectedError)

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/results/ResultTestSupport.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/results/ResultTestSupport.kt
@@ -15,9 +15,9 @@ interface ResultTestSupport {
     ) {
         Assert.assertEquals( result.success, true)
         Assert.assertEquals( result.status.code, (expectedCode ?: expectedStatus.code))
-        Assert.assertEquals( result.status.msg , (expectedMessage ?: expectedStatus.msg))
+        Assert.assertEquals( result.status.desc , (expectedMessage ?: expectedStatus.desc))
         Assert.assertEquals( result.code , (expectedCode ?: expectedStatus.code))
-        Assert.assertEquals( result.msg , (expectedMessage ?: expectedStatus.msg))
+        Assert.assertEquals( result.msg , (expectedMessage ?: expectedStatus.desc))
 
         result.onSuccess { value ->
             Assert.assertEquals(expectedValue, value)
@@ -34,9 +34,9 @@ interface ResultTestSupport {
     ) {
         Assert.assertEquals(result.success , false)
         Assert.assertEquals(result.status.code , (expectedStatusCode ?: expectedStatus.code))
-        Assert.assertEquals(result.status.msg , (expectedStatusMsg ?: expectedStatus.msg))
+        Assert.assertEquals(result.status.desc , (expectedStatusMsg ?: expectedStatus.desc))
         Assert.assertEquals(result.code , (expectedStatusCode ?: expectedStatus.code))
-        Assert.assertEquals(result.msg , (expectedStatusMsg ?: expectedStatus.msg))
+        Assert.assertEquals(result.msg , (expectedStatusMsg ?: expectedStatus.desc))
         result.onFailure {
             when (it) {
                 is String    -> Assert.assertEquals(it , expectedError)

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/results/StatusTests.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/results/StatusTests.kt
@@ -7,9 +7,10 @@ class StatusTests {
 
     @Test
     fun can_build_basic(){
-        val status = Passed.Succeeded(1, "success")
+        val status = Passed.Succeeded("SUCCESS", 1, "success")
+        Assert.assertEquals("SUCCESS", status.name)
         Assert.assertEquals(1, status.code)
-        Assert.assertEquals("success", status.msg)
+        Assert.assertEquals("success", status.desc)
     }
 
 
@@ -17,9 +18,9 @@ class StatusTests {
     fun can_copy_values(){
         fun check(status: Status, code:Int, msg:String){
             Assert.assertEquals(code, status.code)
-            Assert.assertEquals(msg, status.msg)
+            Assert.assertEquals(msg, status.desc)
         }
-        val status = Passed.Succeeded(1, "success")
+        val status = Passed.Succeeded("SUCCESS",1, "success")
         val statusGroup: Status = status
         check(statusGroup.copyAll("ok", 2), 2, "ok")
     }
@@ -30,7 +31,7 @@ class StatusTests {
         fun checkHttp(status:Status, code:Int, msg:String) {
             val result = Codes.toHttp(status)
             Assert.assertEquals(result.first, code)
-            Assert.assertEquals(result.second.msg, msg)
+            Assert.assertEquals(result.second.desc, msg)
         }
         checkHttp(Codes.SUCCESS   , 200, "Success")
         checkHttp(Codes.CONFIRM   , 200, "Confirm")
@@ -74,25 +75,25 @@ class StatusTests {
                 Assert.assertEquals(built, original)
             }
             Assert.assertEquals(code, built.code)
-            Assert.assertEquals(msg , built.msg )
+            Assert.assertEquals(msg , built.desc )
         }
         val status = Codes.SUCCESS
 
         // Empty values
-        check(Status.ofCode(null, null  , status), status.code, status.msg, status,true)
-        check(Status.ofCode(""  , null  , status), status.code, status.msg, status, true)
+        check(Status.ofCode(null, null  , status), status.code, status.desc, status,true)
+        check(Status.ofCode(""  , null  , status), status.code, status.desc, status, true)
 
         // Empty msg or code
-        check(Status.ofCode(status.msg, null  , status), status.code, status.msg, status, true)
-        check(Status.ofCode(null, status.code , status), status.code, status.msg, status, true)
+        check(Status.ofCode(status.desc, null  , status), status.code, status.desc, status, true)
+        check(Status.ofCode(null, status.code , status), status.code, status.desc, status, true)
 
         // Both values supplied but same
-        check(Status.ofCode(status.msg, status.code , status), status.code, status.msg, status, true)
+        check(Status.ofCode(status.desc, status.code , status), status.code, status.desc, status, true)
 
         // Diff values supplied
         check(Status.ofCode("abc", 2  , status), 2, "abc", status, false)
         check(Status.ofCode("abc", null  , status), status.code, "abc", status, false)
-        check(Status.ofCode(null , 2  , status), 2, status.msg, status, false)
+        check(Status.ofCode(null , 2  , status), 2, status.desc, status, false)
 
     }
 
@@ -110,7 +111,7 @@ class StatusTests {
 
     private fun checkCode(Statuses: Status, expectedCode: Int, expectedMsg: String) {
         Assert.assertEquals(Statuses.code, expectedCode)
-        Assert.assertEquals(Statuses.msg, expectedMsg)
+        Assert.assertEquals(Statuses.desc, expectedMsg)
     }
 }
 

--- a/src/lib/kotlin/slatekit/src/main/kotlin/slatekit/SlateKit.kt
+++ b/src/lib/kotlin/slatekit/src/main/kotlin/slatekit/SlateKit.kt
@@ -6,14 +6,12 @@ import slatekit.app.AppOptions
 import slatekit.cli.CliSettings
 import slatekit.context.Context
 import slatekit.common.args.ArgsSchema
-import slatekit.common.types.Content
 import slatekit.common.utils.B64Java8
 import slatekit.common.crypto.Encryptor
 import slatekit.common.info.About
 import slatekit.common.info.ApiKey
 import slatekit.integration.apis.*
 import slatekit.results.Success
-import slatekit.results.Try
 import slatekit.meta.Serialization
 import slatekit.results.Failure
 
@@ -105,7 +103,7 @@ class SlateKit(ctx: Context) : App<Context>(ctx, AppOptions(showWelcome = true))
         val result = cli.executeArgs(copy)
         when(result) {
             is Failure -> println("Failure: " + result.error)
-            is Success -> println("Success: " + result.value.msg)
+            is Success -> println("Success: " + result.value.desc)
         }
     }
 

--- a/src/lib/kotlin/slatekit/src/main/kotlin/slatekit/run.kt
+++ b/src/lib/kotlin/slatekit/src/main/kotlin/slatekit/run.kt
@@ -44,7 +44,8 @@ import slatekit.providers.logs.logback.LogbackLogs
  * 1. slatekit.codegen.toKotlin -templatesFolder="usr://dev/tmp/slatekit/slatekit/scripts/templates/codegen/kotlin" -outputFolder="usr://dev/tmp/codegen/kotlin" -packageName="blendlife"
  */
 fun main(args: Array<String>) {
-    app(args)
+    println("kotlin")
+    //app(args)
     //slatekit.samples.job.main(args)
 }
 


### PR DESCRIPTION
## Overview
Changes to the design of the Result status codes

## Ticket(s) 
n/a

## Links(s) 
n/a

## Dependencies
n/a

## Design
1. Renamed **msg** to **desc**
2. Added a new **name** field to supplement the numeric **code**. 
3. Renamed **Response<T>** msg field to desc and added name just like for Result.

## Notes
1. The new name field is set to the same name as the default codes provided e.g. `"SUCCESS", "INVALID"`

## Pending
n/a

## Tests
Updated tests and fixed compilation issues