### PR TITLE
FEAT: KMP Migration setup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,349 @@
+# Kiit Framework — Claude Code Context
+
+## About Kiit
+
+Kiit is an open-source Kotlin Multiplatform (KMP) framework developed and maintained by CodeHelix. It is a monorepo of modular libraries organized into categories, designed for sharing code across server (JVM/Kotlin), Android, JavaScript/TypeScript, and iOS projects.
+
+- **Domain**  : kiit.dev
+- **GitHub**  : https://github.com/slatekit/kiit
+- **Organization**: CodeHelix
+
+---
+
+## Definition Files — Single Source of Truth
+
+The complete registry of categories, libraries, platform targets, migration state, and metadata is defined in the `./definition/` folder at the repo root.
+
+```
+
+./definition/
+├── kiit-framework-definition.json    ← root: org, enums, category registry
+└── categories/
+    ├── core.json
+    ├── parse.json
+    ├── app.json
+    ├── infra.json
+    ├── resilience.json
+    ├── data.json
+    ├── services.json
+    ├── vendor.json
+    ├── connect.json
+    └── internal.json
+```
+
+**Do not add, rename, or remove libraries or categories in this document.**
+Make all structural changes in the definition files. This document contains
+rules and conventions only — the definition files contain the registry.
+
+All skills read from these files. When performing any task involving a specific
+library or category, always read the relevant category JSON first.
+
+### Target resolution rule
+
+A library's effective platform targets are resolved as follows:
+- If `library.targets` is present → use `library.targets`
+- If `library.targets` is absent  → inherit `category.defaultTargets`
+
+Skills and scripts must always apply this rule. Never assume one or the other
+is always present.
+
+---
+
+## Current State of the Framework
+
+The framework is currently in a pre-migration state. All libraries exist but do not yet
+follow the naming conventions, structure, or build configuration described in this document.
+
+| Concern              | Current State                                              |
+|----------------------|------------------------------------------------------------|
+| Gradle DSL           | Groovy (`build.gradle`)                                    |
+| Kotlin version       | 1.8.x                                                      |
+| Ktor version         | 2.x.x (tied to Kotlin 1.8.x)                              |
+| Gradle version       | 7.x                                                        |
+| Version catalog      | Not in use — versions hardcoded in build files             |
+| Multiplatform (KMP)  | Not configured — JVM only                                  |
+| Folder structure     | Does not match desired category structure                  |
+| Artifact IDs         | Prefixed with `slatekit-` not `kiit-`                      |
+| Package names        | Rooted at `slatekit.*` not `kiit.*`                        |
+| Publishing           | GitHub Packages only                                       |
+| ktlint               | Not configured                                             |
+| Android Gradle Plugin| 7.x                                                        |
+
+The `migration` block in each library's category JSON captures the current artifact ID,
+current package name, current folder location, and migration status for every library.
+
+---
+
+## Desired / Future State of the Framework
+
+| Concern              | Desired State                                              |
+|----------------------|------------------------------------------------------------|
+| Gradle DSL           | Kotlin (`build.gradle.kts`)                                |
+| Kotlin version       | 2.0.21                                                     |
+| Ktor version         | 3.0.1                                                      |
+| Gradle version       | 8.11                                                       |
+| Version catalog      | `gradle/libs.versions.toml` — single source for versions   |
+| Multiplatform (KMP)  | Configured per platform target matrix in definition files  |
+| Folder structure     | Matches category structure under `src/{category}/{library}`|
+| Artifact IDs         | Follow `kiit-{category}-{library}` convention              |
+| Package names        | Rooted at `kiit.*` following naming conventions            |
+| Publishing           | Maven Central (stable), GitHub Packages (pre-release)      |
+| ktlint               | Configured and enforced across all modules                 |
+| Android Gradle Plugin| 8.2.0                                                      |
+
+Versions are managed centrally in `gradle/libs.versions.toml`. No module-level
+`build.gradle.kts` should hardcode a library version — always reference the catalog.
+
+---
+
+## Naming Conventions
+
+### Maven / Gradle
+
+| Element      | Rule                                                                                   | Example             |
+|--------------|----------------------------------------------------------------------------------------|---------------------|
+| `groupId`    | Reverse domain, all lowercase, stable forever. Shared by all kiit libraries.           | `dev.kiit`          |
+| `artifactId` | `kiit-{category}-{library}`, lowercase, hyphen-separated.                              | `kiit-infra-queues` |
+|              | `core` libraries omit the category segment.                                            | `kiit-result`       |
+| Version      | Semantic versioning — `MAJOR.MINOR.PATCH`                                              | `1.0.0`             |
+
+**Hard rules:**
+- Never include platform suffixes (`-android`, `-jvm`, `-js`) in the base `artifactId`.
+  The KMP Gradle plugin appends these automatically on publish.
+- Never use uppercase, underscores, or dots in an `artifactId`.
+- All libraries in all categories share the same `groupId`: `dev.kiit`.
+
+### Kotlin Package Names
+
+| Rule                                                                                  | Example                 |
+|---------------------------------------------------------------------------------------|-------------------------|
+| Mirror the `artifactId`: drop `kiit-`, replace hyphens with dots                     | `kiit.infra.queues`     |
+| All lowercase, dot-separated, no hyphens                                              | `kiit.data.repo`        |
+| Do NOT use `dev.` prefix — `dev.kiit` is a Maven registry concern, not a namespace   | `kiit.result` ✓         |
+| Vendor libraries use dots for sub-segments                                            | `kiit.vendor.aws.sqs`   |
+| Core libraries use a single segment after `kiit`                                      | `kiit.result`           |
+
+### npm / JavaScript
+
+| Rule                                                              | Example              |
+|-------------------------------------------------------------------|----------------------|
+| Scoped under `@kiit`                                              | `@kiit/result`       |
+| Drop the `kiit-` prefix from the artifact ID, keep hyphens       | `@kiit/infra-queues` |
+| Only publish multiplatform libraries (core, infra, app-envs, app-info) | —           |
+
+### iOS / Swift Package Manager
+
+| Rule                                                                    | Example            |
+|-------------------------------------------------------------------------|--------------------|
+| `baseName` is PascalCase concatenation of all artifact ID segments      | `KiitInfraQueues`  |
+| No hyphens, no dots — must be a valid Swift identifier                  | `KiitResult` ✓     |
+| `baseName` must match exactly across all iOS slices                     | —                  |
+| `isStatic = true` unless there is a specific reason for dynamic linking | —                  |
+| Only multiplatform libraries produce an XCFramework                     | —                  |
+
+### Naming Example — `infra / queues`
+
+| Dimension      | Value                  |
+|----------------|------------------------|
+| `groupId`      | `dev.kiit`             |
+| `artifactId`   | `kiit-infra-queues`    |
+| Kotlin package | `kiit.infra.queues`    |
+| npm            | `@kiit/infra-queues`   |
+| iOS `baseName` | `KiitInfraQueues`      |
+
+### Naming Example — `core / result`
+
+| Dimension      | Value           |
+|----------------|-----------------|
+| `groupId`      | `dev.kiit`      |
+| `artifactId`   | `kiit-result`   |
+| Kotlin package | `kiit.result`   |
+| npm            | `@kiit/result`  |
+| iOS `baseName` | `KiitResult`    |
+
+---
+
+## Category Overview
+
+Full category definitions, library lists, platform targets, and migration metadata
+are in `.kiit/definition/categories/{category}.json`. The summary below is for
+orientation only.
+
+| Category     | Artifact prefix          | Default targets           | Published |
+|--------------|--------------------------|---------------------------|-----------|
+| `core`       | `kiit-{library}`         | all platforms             | Yes       |
+| `parse`      | `kiit-parse-{library}`   | all platforms             | Yes       |
+| `app`        | `kiit-app-{library}`     | mixed (see category file) | Yes       |
+| `infra`      | `kiit-infra-{library}`   | all platforms             | Yes       |
+| `resilience` | `kiit-resilience-{lib}`  | all platforms             | Yes       |
+| `data`       | `kiit-data-{library}`    | JVM · Android             | Yes       |
+| `services`   | `kiit-services-{library}`| JVM only                  | Yes       |
+| `vendor`     | `kiit-vendor-{library}`  | JVM only                  | Yes       |
+| `connect`    | `kiit-connect-{library}` | JVM only                  | Yes       |
+| `internal`   | `kiit-internal-{library}`| JVM only                  | No        |
+
+### Core membership test
+
+A library belongs in `core` if **both** conditions are true:
+1. Other kiit libraries depend on it internally (not just consumers).
+2. It has no kiit dependencies of its own.
+
+If a library fails either condition, it belongs in another category.
+
+---
+
+## Dependency Direction Rules
+
+Dependencies must only flow in this direction — never in reverse, never circular:
+
+```
+core       → (no kiit deps)
+parse      → core
+app        → core, parse
+infra      → core
+resilience → core
+data       → core, parse
+services   → core, app, infra, data, resilience
+vendor     → core, infra
+connect    → (any two or more of the above)
+internal   → (anything — never published)
+```
+
+**Hard rules:**
+- `core` libraries must have zero kiit dependencies.
+- `infra` must never depend on `vendor` — never couple abstraction to implementation.
+- `vendor` must never depend on `services` or `connect`.
+- Circular dependencies between any two libraries are never permitted.
+
+---
+
+## Build Infrastructure
+
+### Version catalog
+
+All dependency and plugin versions are managed in `gradle/libs.versions.toml`.
+No `build.gradle.kts` file should hardcode a version string — always use catalog references.
+
+```toml
+[versions]
+kotlin = "2.0.21"
+ktor   = "3.0.1"
+gradle = "8.11"
+agp    = "8.2.0"
+
+[libraries]
+ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
+
+[plugins]
+kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
+```
+
+### Gradle wrapper
+
+The Gradle version is set in `gradle/wrapper/gradle-wrapper.properties`.
+Update via: `./gradlew wrapper --gradle-version {version}`
+
+---
+
+## Documentation Markers
+
+Example source files use XML-style comment markers to tag sections for README generation.
+The tag format is:
+
+```kotlin
+//<doc:examples>
+// ... code ...
+//</doc:examples>
+```
+
+Valid tags (defined in `kiit-framework-definition.json` under `docTags`):
+
+| Tag                  | Purpose                                                    |
+|----------------------|------------------------------------------------------------|
+| `import_required`    | Imports the consumer must add to use the library           |
+| `import_examples`    | Additional imports used only within the example code       |
+| `examples`           | Primary usage examples                                     |
+| `examples_support`   | Helper and support functions used by the examples          |
+| `output`             | Expected console output, wrapped in Hugo highlight block   |
+
+Example files currently reference `slatekit.*` package names. The `kiit-docs-generate-readme`
+skill must translate these to `kiit.*` equivalents using `migration.currentPackage` →
+`library.package` mapping from the category JSON before writing the README.
+
+---
+
+## Contribution Tiers
+
+| Tier      | Repo                              | groupId        | Maintained by  | Published to          |
+|-----------|-----------------------------------|----------------|----------------|-----------------------|
+| Official  | `github.com/slatekit/kiit`        | `dev.kiit`     | CodeHelix      | Maven Central         |
+| Extension | `github.com/slatekit/kiit-ext`    | `dev.kiit.ext` | Contributor    | Maven Central / GH    |
+| Community | Author's own repo                 | Author's own   | Author         | Author's choice       |
+
+---
+
+## Open-Source Publishing Requirements
+
+Every artifact published to Maven Central must have:
+
+- [ ] Sources JAR (`-sources.jar`)
+- [ ] Dokka JAR (`-javadoc.jar`)
+- [ ] GPG signature on all artifacts
+- [ ] POM with: `name`, `description`, `url`, `licenses`, `developers`, `scm`
+- [ ] Semantic version tag on the git commit
+
+Pre-release artifacts (alpha, beta, RC) → GitHub Packages only.
+Stable releases → Maven Central.
+
+---
+
+## API Stability Annotations
+
+```kotlin
+@RequiresOptIn(
+    message = "This kiit API is experimental. It may change without notice.",
+    level = RequiresOptIn.Level.WARNING
+)
+annotation class ExperimentalKiitApi
+
+@RequiresOptIn(
+    message = "This is an internal kiit API. Do not use in consumer code.",
+    level = RequiresOptIn.Level.ERROR
+)
+annotation class InternalKiitApi
+```
+
+| Category     | Default stability |
+|--------------|-------------------|
+| `core`       | stable            |
+| `parse`      | stable            |
+| `app`        | experimental      |
+| `infra`      | stable            |
+| `resilience` | experimental      |
+| `data`       | stable            |
+| `services`   | experimental      |
+| `vendor`     | stable            |
+| `connect`    | experimental      |
+
+---
+
+## Platform-Specific Notes
+
+### iOS / SPM
+- XCFramework `baseName` must be identical across `iosArm64`, `iosSimulatorArm64`, and `iosX64`.
+- Kotlin packages are stripped at the Swift boundary — class names must be unique within a framework.
+- Use `@ObjCName` to control Swift-visible names where the default is awkward.
+- `suspend` functions require either the `KMP-NativeCoroutines` library or the `skie` plugin.
+
+### JS / TypeScript
+- Always use the IR compiler: `js(IR)`.
+- Always declare `binaries.library()` — never `binaries.executable()` for library modules.
+- Annotate all public API declarations with `@JsExport`.
+- Call `generateTypeScriptDefinitions()` to emit `.d.ts` files.
+
+### JVM / Java Interop
+- Kiit is Kotlin-first. Java compatibility is a courtesy, not a requirement.
+- Use `@JvmStatic` on companion object members.
+- Use `@JvmOverloads` on functions with default parameters.
+- Use `@JvmName` to resolve accessor name conflicts.
+- Avoid exposing `suspend` functions at the Java API boundary without a wrapper.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,20 +54,20 @@ is always present.
 The framework is currently in a pre-migration state. All libraries exist but do not yet
 follow the naming conventions, structure, or build configuration described in this document.
 
-| Concern              | Current State                                              |
-|----------------------|------------------------------------------------------------|
-| Gradle DSL           | Groovy (`build.gradle`)                                    |
-| Kotlin version       | 1.8.x                                                      |
-| Ktor version         | 2.x.x (tied to Kotlin 1.8.x)                              |
-| Gradle version       | 7.x                                                        |
-| Version catalog      | Not in use — versions hardcoded in build files             |
-| Multiplatform (KMP)  | Not configured — JVM only                                  |
-| Folder structure     | Does not match desired category structure                  |
-| Artifact IDs         | Prefixed with `slatekit-` not `kiit-`                      |
-| Package names        | Rooted at `slatekit.*` not `kiit.*`                        |
-| Publishing           | GitHub Packages only                                       |
-| ktlint               | Not configured                                             |
-| Android Gradle Plugin| 7.x                                                        |
+| Concern                | Current State                                                  |
+|------------------------|----------------------------------------------------------------|
+| Gradle DSL             | Groovy (`build.gradle`)                                        |
+| Kotlin version         | 1.9.x                                                          |
+| Ktor version           | 2.x.x (tied to Kotlin 1.8.x)                                   |
+| Gradle version         | 8.x                                                            |
+| Version catalog        | Not in use — versions hardcoded in build files                 |
+| Multiplatform (KMP)    | Not configured — JVM only                                      |
+| Folder structure       | Does not match desired category structure                      |
+| Artifact IDs           | Prefixed with `kiit-{library}` not `kiit-{category}-{library}` |
+| Package names          | Rooted at `kiit.*` not `kiit.{category}.{library}*`            |
+| Publishing             | GitHub Packages only                                           |
+| ktlint                 | Not configured                                                 |
+| Android Gradle Plugin  | 7.x                                                            |
 
 The `migration` block in each library's category JSON captures the current artifact ID,
 current package name, current folder location, and migration status for every library.
@@ -76,20 +76,20 @@ current package name, current folder location, and migration status for every li
 
 ## Desired / Future State of the Framework
 
-| Concern              | Desired State                                              |
-|----------------------|------------------------------------------------------------|
-| Gradle DSL           | Kotlin (`build.gradle.kts`)                                |
-| Kotlin version       | 2.0.21                                                     |
-| Ktor version         | 3.0.1                                                      |
-| Gradle version       | 8.11                                                       |
-| Version catalog      | `gradle/libs.versions.toml` — single source for versions   |
-| Multiplatform (KMP)  | Configured per platform target matrix in definition files  |
-| Folder structure     | Matches category structure under `src/{category}/{library}`|
-| Artifact IDs         | Follow `kiit-{category}-{library}` convention              |
-| Package names        | Rooted at `kiit.*` following naming conventions            |
-| Publishing           | Maven Central (stable), GitHub Packages (pre-release)      |
-| ktlint               | Configured and enforced across all modules                 |
-| Android Gradle Plugin| 8.2.0                                                      |
+| Concern                | Desired State                                               |
+|------------------------|-------------------------------------------------------------|
+| Gradle DSL             | Kotlin (`build.gradle.kts`)                                 |
+| Kotlin version         | 2.3.21                                                      |
+| Ktor version           | 3.x                                                         |
+| Gradle version         | 8.11                                                        |
+| Version catalog        | `gradle/libs.versions.toml` — single source for versions    |
+| Multiplatform (KMP)    | Configured per platform target matrix in definition files   |
+| Folder structure       | Matches category structure under `src/{category}/{library}` |
+| Artifact IDs           | Follow `kiit-{category}-{library}` convention               |
+| Package names          | Rooted at `kiit.*` following naming conventions             |
+| Publishing             | Maven Central (stable), GitHub Packages (pre-release)       |
+| ktlint                 | Configured and enforced across all modules                  |
+| Android Gradle Plugin  | 8.2.0                                                       |
 
 Versions are managed centrally in `gradle/libs.versions.toml`. No module-level
 `build.gradle.kts` should hardcode a library version — always reference the catalog.
@@ -115,21 +115,21 @@ Versions are managed centrally in `gradle/libs.versions.toml`. No module-level
 
 ### Kotlin Package Names
 
-| Rule                                                                                  | Example                 |
-|---------------------------------------------------------------------------------------|-------------------------|
-| Mirror the `artifactId`: drop `kiit-`, replace hyphens with dots                     | `kiit.infra.queues`     |
-| All lowercase, dot-separated, no hyphens                                              | `kiit.data.repo`        |
-| Do NOT use `dev.` prefix — `dev.kiit` is a Maven registry concern, not a namespace   | `kiit.result` ✓         |
-| Vendor libraries use dots for sub-segments                                            | `kiit.vendor.aws.sqs`   |
-| Core libraries use a single segment after `kiit`                                      | `kiit.result`           |
+| Rule                                                                                   | Example                 |
+|----------------------------------------------------------------------------------------|-------------------------|
+| Mirror the `artifactId`: drop `kiit-`, replace hyphens with dots                       | `kiit.infra.queues`     |
+| All lowercase, dot-separated, no hyphens                                               | `kiit.data.repo`        |
+| Do NOT use `dev.` prefix — `dev.kiit` is a Maven registry concern, not a namespace     | `kiit.result` ✓         |
+| Vendor libraries use dots for sub-segments                                             | `kiit.vendor.aws.sqs`   |
+| Core libraries use a single segment after `kiit`                                       | `kiit.result`           |
 
 ### npm / JavaScript
 
-| Rule                                                              | Example              |
-|-------------------------------------------------------------------|----------------------|
-| Scoped under `@kiit`                                              | `@kiit/result`       |
-| Drop the `kiit-` prefix from the artifact ID, keep hyphens       | `@kiit/infra-queues` |
-| Only publish multiplatform libraries (core, infra, app-envs, app-info) | —           |
+| Rule                                                                   | Example              |
+|------------------------------------------------------------------------|----------------------|
+| Scoped under `@kiit`                                                   | `@kiit/result`       |
+| Drop the `kiit-` prefix from the artifact ID, keep hyphens             | `@kiit/infra-queues` |
+| Only publish multiplatform libraries (core, infra, app-envs, app-info) | —                    |
 
 ### iOS / Swift Package Manager
 
@@ -169,26 +169,27 @@ Full category definitions, library lists, platform targets, and migration metada
 are in `.kiit/definition/categories/{category}.json`. The summary below is for
 orientation only.
 
-| Category     | Artifact prefix          | Default targets           | Published |
-|--------------|--------------------------|---------------------------|-----------|
-| `core`       | `kiit-{library}`         | all platforms             | Yes       |
-| `parse`      | `kiit-parse-{library}`   | all platforms             | Yes       |
-| `app`        | `kiit-app-{library}`     | mixed (see category file) | Yes       |
-| `infra`      | `kiit-infra-{library}`   | all platforms             | Yes       |
-| `resilience` | `kiit-resilience-{lib}`  | all platforms             | Yes       |
-| `data`       | `kiit-data-{library}`    | JVM · Android             | Yes       |
-| `services`   | `kiit-services-{library}`| JVM only                  | Yes       |
-| `vendor`     | `kiit-vendor-{library}`  | JVM only                  | Yes       |
-| `connect`    | `kiit-connect-{library}` | JVM only                  | Yes       |
-| `internal`   | `kiit-internal-{library}`| JVM only                  | No        |
+| Category     | Artifact prefix            | Default targets           | Published |
+|--------------|----------------------------|---------------------------|-----------|
+| `core`       | `kiit-{library}`           | all platforms             | Yes       |
+| `parse`      | `kiit-parse-{library}`     | all platforms             | Yes       |
+| `app`        | `kiit-app-{library}`       | mixed (see category file) | Yes       |
+| `infra`      | `kiit-infra-{library}`     | all platforms             | Yes       |
+| `resilience` | `kiit-resilience-{lib}`    | all platforms             | Yes       |
+| `data`       | `kiit-data-{library}`      | JVM · Android             | Yes       |
+| `services`   | `kiit-services-{library}`  | JVM only                  | Yes       |
+| `vendor`     | `kiit-vendor-{library}`    | JVM only                  | Yes       |
+| `connect`    | `kiit-connect-{library}`   | JVM only                  | Yes       |
+| `internal`   | `kiit-internal-{library}`  | JVM only                  | No        |
 
 ### Core membership test
 
 A library belongs in `core` if **both** conditions are true:
 1. Other kiit libraries depend on it internally (not just consumers).
-2. It has no kiit dependencies of its own.
+2. It only depends on other kiit `core` dependencies or ideally none at all.
+3. It can NOT depend on any kiit dependencies in other categories.
 
-If a library fails either condition, it belongs in another category.
+If a library fails these conditions, it belongs in another category.
 
 ---
 

--- a/definition/categories/core.json
+++ b/definition/categories/core.json
@@ -1,0 +1,124 @@
+{
+  "key"                   : "core",
+  "description"           : "Foundational primitives depended on by other kiit libraries internally. Must have no kiit dependencies of their own. No category segment in artifactId or package name.",
+  "omitCategoryInArtifact": true,
+  "defaultTargets"        : ["jvm", "android", "js", "ios"],
+  "location": {
+    "current": "src/lib/kotlin/slatekit-common",
+    "desired": "src/core"
+  },
+  "build": {
+    "current": {
+      "dsl"           : "groovy",
+      "multiplatform" : false,
+      "publishing"    : "github-packages",
+      "versionCatalog": false,
+      "ktlint"        : false
+    },
+    "desired": {
+      "dsl"           : "kotlin",
+      "multiplatform" : true,
+      "publishing"    : "maven-central",
+      "versionCatalog": true,
+      "ktlint"        : true
+    }
+  },
+  "libraries": [
+    {
+      "name"       : "result",
+      "description": "Custom Result<T, E> / Outcome monad for typed success and failure without exceptions",
+      "artifactId" : "kiit-result",
+      "package"    : "kiit.result",
+      "npm"        : "@kiit/result",
+      "ios"        : { "baseName": "KiitResult" },
+      "targets"    : ["jvm", "android", "js", "ios"],
+      "stability"  : "stable",
+      "published"  : true,
+      "migration"  : {
+        "status"            : "pending",
+        "currentArtifactId" : "slatekit-result",
+        "currentPackage"    : "slatekit.results",
+        "currentLocation"   : "src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/results",
+        "desiredLocation"   : "src/core/result",
+        "notes"             : ""
+      },
+      "docs": {
+        "exampleFile": "src/apps/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Result.kt",
+        "readme"     : "src/core/result/README.md",
+        "tags"       : ["import_required", "import_examples", "examples", "examples_support", "output"]
+      }
+    },
+    {
+      "name"       : "codes",
+      "description": "Typed status and error codes used by kiit-result for structured success and failure classification",
+      "artifactId" : "kiit-codes",
+      "package"    : "kiit.codes",
+      "npm"        : "@kiit/codes",
+      "ios"        : { "baseName": "KiitCodes" },
+      "targets"    : ["jvm", "android", "js", "ios"],
+      "stability"  : "stable",
+      "published"  : true,
+      "migration"  : {
+        "status"            : "pending",
+        "currentArtifactId" : "slatekit-common",
+        "currentPackage"    : "slatekit.common.codes",
+        "currentLocation"   : "src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/codes",
+        "desiredLocation"   : "src/core/codes",
+        "notes"             : ""
+      },
+      "docs": {
+        "exampleFile": "src/apps/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Codes.kt",
+        "readme"     : "src/core/codes/README.md",
+        "tags"       : ["import_required", "import_examples", "examples", "output"]
+      }
+    },
+    {
+      "name"       : "identity",
+      "description": "Fully qualified resource and service ID primitives with structured naming conventions",
+      "artifactId" : "kiit-identity",
+      "package"    : "kiit.identity",
+      "npm"        : "@kiit/identity",
+      "ios"        : { "baseName": "KiitIdentity" },
+      "targets"    : ["jvm", "android", "js", "ios"],
+      "stability"  : "stable",
+      "published"  : true,
+      "migration"  : {
+        "status"            : "pending",
+        "currentArtifactId" : "slatekit-common",
+        "currentPackage"    : "slatekit.common.identity",
+        "currentLocation"   : "src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/identity",
+        "desiredLocation"   : "src/core/identity",
+        "notes"             : ""
+      },
+      "docs": {
+        "exampleFile": "src/apps/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Identity.kt",
+        "readme"     : "src/core/identity/README.md",
+        "tags"       : ["import_required", "import_examples", "examples", "output"]
+      }
+    },
+    {
+      "name"       : "emitter",
+      "description": "JavaScript-style in-memory event emitter for typed in-process publish/subscribe",
+      "artifactId" : "kiit-emitter",
+      "package"    : "kiit.emitter",
+      "npm"        : "@kiit/emitter",
+      "ios"        : { "baseName": "KiitEmitter" },
+      "targets"    : ["jvm", "android", "js", "ios"],
+      "stability"  : "experimental",
+      "published"  : true,
+      "migration"  : {
+        "status"            : "pending",
+        "currentArtifactId" : "slatekit-common",
+        "currentPackage"    : "slatekit.common.emitter",
+        "currentLocation"   : "src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/emitter",
+        "desiredLocation"   : "src/core/emitter",
+        "notes"             : ""
+      },
+      "docs": {
+        "exampleFile": "src/apps/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Emitter.kt",
+        "readme"     : "src/core/emitter/README.md",
+        "tags"       : ["import_required", "import_examples", "examples", "output"]
+      }
+    }
+  ]
+}

--- a/definition/categories/infra.json
+++ b/definition/categories/infra.json
@@ -1,0 +1,100 @@
+{
+  "key"                   : "infra",
+  "description"           : "Abstractions for infrastructure concerns. Interfaces, types, and in-memory implementations only. No vendor SDK dependencies. Consumers depend on these directly and swap in vendor implementations via the vendor category.",
+  "omitCategoryInArtifact": false,
+  "defaultTargets"        : ["jvm", "android", "js", "ios"],
+  "location": {
+    "current": "src/lib/kotlin/slatekit-core",
+    "desired": "src/infra"
+  },
+  "build": {
+    "current": {
+      "dsl"           : "groovy",
+      "multiplatform" : false,
+      "publishing"    : "github-packages",
+      "versionCatalog": false,
+      "ktlint"        : false
+    },
+    "desired": {
+      "dsl"           : "kotlin",
+      "multiplatform" : true,
+      "publishing"    : "maven-central",
+      "versionCatalog": true,
+      "ktlint"        : true
+    }
+  },
+  "libraries": [
+    {
+      "name"       : "queues",
+      "description": "Queue abstraction for async messaging. Includes interface, types, and an in-memory implementation. Vendor implementations live in kiit-vendor-aws-sqs etc.",
+      "artifactId" : "kiit-infra-queues",
+      "package"    : "kiit.infra.queues",
+      "npm"        : "@kiit/infra-queues",
+      "ios"        : { "baseName": "KiitInfraQueues" },
+      "targets"    : ["jvm", "android", "js", "ios"],
+      "stability"  : "stable",
+      "published"  : true,
+      "migration"  : {
+        "status"            : "pending",
+        "currentArtifactId" : "slatekit-core",
+        "currentPackage"    : "slatekit.core.queues",
+        "currentLocation"   : "src/lib/kotlin/slatekit-core/src/main/kotlin/slatekit/core/queues",
+        "desiredLocation"   : "src/infra/queues",
+        "notes"             : ""
+      },
+      "docs": {
+        "exampleFile": "src/apps/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Queue.kt",
+        "readme"     : "src/infra/queues/README.md",
+        "tags"       : ["import_required", "import_examples", "examples", "examples_support", "output"]
+      }
+    },
+    {
+      "name"       : "files",
+      "description": "File storage abstraction for reading and writing binary and text content. Includes interface, types, and an in-memory implementation. Vendor implementations live in kiit-vendor-aws-s3 etc.",
+      "artifactId" : "kiit-infra-files",
+      "package"    : "kiit.infra.files",
+      "npm"        : "@kiit/infra-files",
+      "ios"        : { "baseName": "KiitInfraFiles" },
+      "targets"    : ["jvm", "android", "js", "ios"],
+      "stability"  : "stable",
+      "published"  : true,
+      "migration"  : {
+        "status"            : "pending",
+        "currentArtifactId" : "slatekit-core",
+        "currentPackage"    : "slatekit.core.files",
+        "currentLocation"   : "src/lib/kotlin/slatekit-core/src/main/kotlin/slatekit/core/files",
+        "desiredLocation"   : "src/infra/files",
+        "notes"             : ""
+      },
+      "docs": {
+        "exampleFile": "src/apps/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Files.kt",
+        "readme"     : "src/infra/files/README.md",
+        "tags"       : ["import_required", "import_examples", "examples", "examples_support", "output"]
+      }
+    },
+    {
+      "name"       : "cache",
+      "description": "Cache abstraction for key-value storage with expiry. Includes interface, types, and an in-memory implementation. Vendor implementations live in kiit-vendor-redis etc.",
+      "artifactId" : "kiit-infra-cache",
+      "package"    : "kiit.infra.cache",
+      "npm"        : "@kiit/infra-cache",
+      "ios"        : { "baseName": "KiitInfraCache" },
+      "targets"    : ["jvm", "android", "js", "ios"],
+      "stability"  : "stable",
+      "published"  : true,
+      "migration"  : {
+        "status"            : "pending",
+        "currentArtifactId" : "slatekit-core",
+        "currentPackage"    : "slatekit.core.cache",
+        "currentLocation"   : "src/lib/kotlin/slatekit-core/src/main/kotlin/slatekit/core/cache",
+        "desiredLocation"   : "src/infra/cache",
+        "notes"             : ""
+      },
+      "docs": {
+        "exampleFile": "src/apps/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Cache.kt",
+        "readme"     : "src/infra/cache/README.md",
+        "tags"       : ["import_required", "import_examples", "examples", "examples_support", "output"]
+      }
+    }
+  ]
+}

--- a/definition/categories/stdlib.json
+++ b/definition/categories/stdlib.json
@@ -1,0 +1,52 @@
+{
+  "key"                   : "stdlib",
+  "description"           : "Abstractions for infrastructure concerns. Interfaces, types, and in-memory implementations only. No vendor SDK dependencies. Consumers depend on these directly and swap in vendor implementations via the vendor category.",
+  "omitCategoryInArtifact": false,
+  "defaultTargets"        : ["jvm", "android", "js", "ios"],
+  "location": {
+    "current": "src/common/common",
+    "desired": "src/stdlib"
+  },
+  "build": {
+    "current": {
+      "dsl"           : "groovy",
+      "multiplatform" : false,
+      "publishing"    : "github-packages",
+      "versionCatalog": false,
+      "ktlint"        : false
+    },
+    "desired": {
+      "dsl"           : "kotlin",
+      "multiplatform" : true,
+      "publishing"    : "maven-central",
+      "versionCatalog": true,
+      "ktlint"        : true
+    }
+  },
+  "libraries": [
+    {
+      "name"       : "args",
+      "description": "Command line arguments parser with fully qualified names, meta arguments and more.",
+      "artifactId" : "kiit-stdlib-args",
+      "package"    : "kiit.stdlib.args",
+      "npm"        : "@kiit/stdlib-args",
+      "ios"        : { "baseName": "KiitStdlibArgs" },
+      "targets"    : ["jvm", "android", "js", "ios"],
+      "stability"  : "stable",
+      "published"  : true,
+      "migration"  : {
+        "status"            : "pending",
+        "currentArtifactId" : "kiit-common",
+        "currentPackage"    : "kiit.common.args",
+        "currentLocation"   : "src/common/common/src/main/kotlin/kiit/common/args",
+        "desiredLocation"   : "src/stdlib/args",
+        "notes"             : "Currently a package within the common sub-project"
+      },
+      "docs": {
+        "exampleFile": "src/apps/kotlin/slatekit-examples/src/main/kotlin/slatekit/examples/Example_Args.kt",
+        "readme"     : "src/stdlib/args/README.md",
+        "tags"       : ["import_required", "import_examples", "examples", "examples_support", "output"]
+      }
+    }
+  ]
+}

--- a/definition/kiit-framework-definition.json
+++ b/definition/kiit-framework-definition.json
@@ -1,0 +1,149 @@
+{
+  "version": "1.0.0",
+  "organization": {
+    "name"  : "CodeHelix",
+    "group" : "dev.kiit",
+    "domain": "kiit.dev",
+    "github": "https://github.com/slatekit/kiit",
+    "npm": {
+      "scope"   : "@kiit",
+      "registry": "https://registry.npmjs.org"
+    },
+    "maven": {
+      "central"   : "https://repo1.maven.org/maven2",
+      "prerelease": "https://maven.pkg.github.com/slatekit/kiit"
+    }
+  },
+  "build": {
+    "current": {
+      "kotlin"      : "1.8.x",
+      "ktor"        : "2.x.x",
+      "gradle"      : "7.x",
+      "agp"         : "7.x",
+      "dsl"         : "groovy",
+      "versionCatalog": false
+    },
+    "desired": {
+      "kotlin"      : "2.0.21",
+      "ktor"        : "3.0.1",
+      "gradle"      : "8.11",
+      "agp"         : "8.2.0",
+      "dsl"         : "kotlin",
+      "versionCatalog": true
+    }
+  },
+  "targets": {
+    "description": "Valid platform targets for kiit libraries",
+    "items": [
+      { "key": "jvm",     "description": "Kotlin / Java server-side JVM"         },
+      { "key": "android", "description": "Android via AAR"                        },
+      { "key": "js",      "description": "JavaScript / TypeScript via npm"        },
+      { "key": "ios",     "description": "iOS / macOS via XCFramework and SPM"    }
+    ]
+  },
+  "stability": {
+    "description": "Valid stability levels for kiit libraries",
+    "items": [
+      { "key": "stable",       "description": "Production ready. No breaking changes without a major version bump." },
+      { "key": "experimental", "description": "API may change. Opt-in via @ExperimentalKiitApi."                   },
+      { "key": "internal",     "description": "Not for consumer use. Annotated @InternalKiitApi."                  },
+      { "key": "deprecated",   "description": "Scheduled for removal. Migration notes in library README."           }
+    ]
+  },
+  "migration": {
+    "description": "Migration status for each library from current to desired state",
+    "items": [
+      { "key": "pending",    "description": "Not yet started"                                        },
+      { "key": "inProgress", "description": "Migration underway, not yet verified"                   },
+      { "key": "partial",    "description": "Some aspects migrated, others still pending"            },
+      { "key": "complete",   "description": "Fully migrated and verified"                            },
+      { "key": "removed",    "description": "Library removed, no longer part of kiit"               }
+    ]
+  },
+  "docTags": {
+    "description": "Valid documentation marker tags used in Kotlin example source files",
+    "syntax"     : "//<doc:{key}> ... //</doc:{key}>",
+    "items": [
+      { "key": "import_required",  "description": "Imports the consumer must add to use the library"        },
+      { "key": "import_examples",  "description": "Additional imports used only within the example code"    },
+      { "key": "examples",         "description": "Primary usage examples for the library"                  },
+      { "key": "examples_support", "description": "Helper and support functions used by the examples"       },
+      { "key": "output",           "description": "Expected console output, wrapped in Hugo highlight block" }
+    ]
+  },
+  "categories": {
+    "description": "All kiit library categories. Each category maps to a segment in the artifactId and Kotlin package name, except where omitCategoryInArtifact is true. Libraries and full metadata are defined in each category's definitionFile.",
+    "items": [
+      {
+        "key"                   : "core",
+        "description"           : "Foundational primitives depended on by other kiit libraries internally. Must have no kiit dependencies of their own. No category segment in artifactId or package name.",
+        "omitCategoryInArtifact": true,
+        "defaultTargets"        : ["jvm", "android", "js", "ios"],
+        "definitionFile"        : "categories/core.json"
+      },
+      {
+        "key"                   : "parse",
+        "description"           : "Text and naming utilities for lexical parsing and naming conventions. Pure logic, no I/O. Consumed internally by identity, data, and conf. Rarely depended on directly by consumers.",
+        "omitCategoryInArtifact": false,
+        "defaultTargets"        : ["jvm", "android", "js", "ios"],
+        "definitionFile"        : "categories/parse.json"
+      },
+      {
+        "key"                   : "app",
+        "description"           : "Application bootstrap and runtime context. Libraries for environment selection, config loading, directory layout, CLI args, and startup banners.",
+        "omitCategoryInArtifact": false,
+        "defaultTargets"        : ["jvm", "android", "js", "ios"],
+        "definitionFile"        : "categories/app.json"
+      },
+      {
+        "key"                   : "infra",
+        "description"           : "Abstractions for infrastructure concerns. Interfaces, types, and in-memory implementations only. No vendor SDK dependencies.",
+        "omitCategoryInArtifact": false,
+        "defaultTargets"        : ["jvm", "android", "js", "ios"],
+        "definitionFile"        : "categories/infra.json"
+      },
+      {
+        "key"                   : "resilience",
+        "description"           : "Flow control and fault tolerance primitives. Libraries that protect systems from overload, cascading failure, and resource exhaustion.",
+        "omitCategoryInArtifact": false,
+        "defaultTargets"        : ["jvm", "android", "js", "ios"],
+        "definitionFile"        : "categories/resilience.json"
+      },
+      {
+        "key"                   : "data",
+        "description"           : "Database access abstractions and opinionated implementations. Low-level SQL, repository pattern, and entity service layer.",
+        "omitCategoryInArtifact": false,
+        "defaultTargets"        : ["jvm", "android"],
+        "definitionFile"        : "categories/data.json"
+      },
+      {
+        "key"                   : "services",
+        "description"           : "Runnable application templates and higher-level service libraries. Application base, background jobs, and RPC-style API server.",
+        "omitCategoryInArtifact": false,
+        "defaultTargets"        : ["jvm"],
+        "definitionFile"        : "categories/services.json"
+      },
+      {
+        "key"                   : "vendor",
+        "description"           : "Concrete implementations of infra abstractions using real vendor SDKs. JVM only. Never depended on by other kiit libraries.",
+        "omitCategoryInArtifact": false,
+        "defaultTargets"        : ["jvm"],
+        "definitionFile"        : "categories/vendor.json"
+      },
+      {
+        "key"                   : "connect",
+        "description"           : "Connector libraries that wire two or more kiit libraries together.",
+        "omitCategoryInArtifact": false,
+        "defaultTargets"        : ["jvm"],
+        "definitionFile"        : "categories/connect.json"
+      },
+      {
+        "key"                   : "internal",
+        "description"           : "Internal libraries used only within the kiit monorepo for build or test purposes. Never published externally.",
+        "omitCategoryInArtifact": false,
+        "defaultTargets"        : ["jvm"],
+        "definitionFile"        : "categories/internal.json"
+      }
+    ]
+  }
+}

--- a/definition/kiit-framework-definition.json
+++ b/definition/kiit-framework-definition.json
@@ -82,18 +82,11 @@
         "definitionFile"        : "categories/core.json"
       },
       {
-        "key"                   : "parse",
-        "description"           : "Text and naming utilities for lexical parsing and naming conventions. Pure logic, no I/O. Consumed internally by identity, data, and conf. Rarely depended on directly by consumers.",
+        "key"                   : "stdlib",
+        "description"           : "Supplemental utilities and libraries to a standard library, such as arguments parser, config file loading, environemnt selection.",
         "omitCategoryInArtifact": false,
         "defaultTargets"        : ["jvm", "android", "js", "ios"],
-        "definitionFile"        : "categories/parse.json"
-      },
-      {
-        "key"                   : "app",
-        "description"           : "Application bootstrap and runtime context. Libraries for environment selection, config loading, directory layout, CLI args, and startup banners.",
-        "omitCategoryInArtifact": false,
-        "defaultTargets"        : ["jvm", "android", "js", "ios"],
-        "definitionFile"        : "categories/app.json"
+        "definitionFile"        : "categories/stdlib.json"
       },
       {
         "key"                   : "infra",


### PR DESCRIPTION
## Overview
This PR establishes the foundational naming conventions, category structure, build configuration targets, and Claude Code tooling for the kiit framework restructure. It introduces the `./definition/` schema files and `.claude/skills/` (not included in this PR ) to support the migration from the current `kiit-*` setup to the new `kiit-*` multiplatform architecture.

## Ticket(s)
TBD

## Link(s)
- Framework domain: https://kiit.dev
- GitHub: https://github.com/slatekit/kiit ( this repo )
- Maven Central: https://repo1.maven.org/maven2
- npm scope: https://www.npmjs.com/org/dev-kiit
- SPM : https://github.com/slatekit/kiit-spm ( to be used for storing KMM swift packages / artifacts )

## Dependencies
1. Claude

## Design
The following design decisions were made and are now codified in `CLAUDE.md` and the `.kiit/definition/` files.

**Naming Conventions**
1. `groupId` is `dev.kiit` — reverse domain of `kiit.dev`, shared by all libraries across all categories.
2. `artifactId` follows `kiit-{category}-{library}` with the exception of `core` libraries which omit the category segment (e.g. `kiit-result`).
3. Kotlin package names mirror the artifact ID with hyphens replaced by dots, rooted at `kiit.*` with no `dev.` prefix.
4. npm scope is `@dev-kiit` (mirrors `dev.kiit` with dot replaced by hyphen) — `@kiit` was unavailable on npmjs.
5. iOS `baseName` is PascalCase concatenation of all artifact ID segments (e.g. `KiitInfraQueues`).

**Category Structure**
1. Introduced categories: `core`, `stdlib`, `infra`,  `data`, `services`, `vendor`, `connect`, `internal`.
2. `core` libraries carry no category prefix in artifact ID or package — membership requires passing a two-part test: other kiit libraries depend on it internally, and it has no kiit dependencies of its own.
3. `stdlib` is a new intentional category for standard library augmentation (args, envs, conf, info, dirs, logs) — hard cap of 12 libraries encoded in the schema, each library independently consumable with no stdlib siblings as dependencies.
4. `vendor` houses all concrete infrastructure and logging implementations including `kiit-vendor-logs-slf4j`.

**`stdlib` and Logging**
1. `kiit-stdlib-logs` is placed in `stdlib` (not `core`) — a logging facade with console implementation, opt-in only.
2. No kiit library below `stdlib` in the dependency graph logs — errors surface through `kiit-result`.
3. SLF4J implementation lives in `kiit-vendor-logs-slf4j` in the `vendor` category.

**Dependency Direction Rules**
1. Dependency flow is strictly one-directional: `core` → `stdlib` with `infra`, `data`, `services` branching from `core`, and `services` depending on all of the above.
2. `infra` must never depend on `vendor` — abstraction must not couple to implementation.
3. `core` libraries must have zero kiit dependencies.

**Build and Publishing**
1. Target build migrates from Groovy DSL + Kotlin 1.8.x + Gradle 7.x to Kotlin DSL + Kotlin 2.3.21 + Gradle 8.11.
2. All libraries migrate from GitHub Packages only to Maven Central (stable) and GitHub Packages (pre-release).
3. Version catalog introduced at `gradle/libs.versions.toml` — no hardcoded versions in any `build.gradle.kts`.
4. KMP configured per platform target matrix defined in the definition files.

**Definition Files**
1. Introduced `.definition/kiit-framework-definition.json` as the root schema — org metadata, enums (targets, stability, migration, docTags), and category registry.
2. Each category has its own `categories/{category}.json` with full library entries, migration metadata (current/desired location, artifact ID, package), and docs configuration.
3. Each library entry carries `migration.status` (pending, inProgress, partial, complete, removed) to track progress.
4. `docs` block per library references the example source file, README output path, and expected doc marker tags for README generation.

**Claude Code Tooling**
1. `CLAUDE.md` added at repo root with persistent framework context including naming rules, category overview, current state, desired state, dependency directions, and platform-specific notes.
2. 25 skills added under `.kiit/skills/{skill-name}/SKILL.md` covering audit, migration, scaffolding, validation, versions, lint, documentation, and maintenance workflows. ( part of separate PR ).

## Notes
1. The `currentLocation` paths in `core.json` and `infra.json` are inferred from the existing repo structure — verify against actual paths before running any migration skills.
2. The npm scope `@kiit` was unavailable — `@dev-kiit` was reserved and is used throughout. Update any existing npm references.
3. `internal` libraries are published but for internal purposes only.

## Pending
1. Remaining category JSON files to be populated: `stdlib`,  `data`, `services`, `vendor`, `connect`, `internal`.
2. Verify `currentLocation` paths in `core.json` and `infra.json` against actual repo structure.
3. Claim `@dev-kiit` scope on npmjs.com if not already done.
4. Verify domain ownership for `dev.kiit` groupId through Sonatype Central Portal.
5. GPG key generation for Maven Central signing.
6. `gradle/libs.versions.toml` version catalog to be created.
7. All 36 existing libraries to be migrated — tracked via `migration.status` in each category JSON.

## Tests
1. No application tests in this PR — structural and tooling changes only.
2. `kiit-check-definition` skill can be run against `core.json` and `infra.json` to validate schema correctness.
3. `kiit-audit-naming` skill can be run to validate naming conventions once libraries are migrated.