### PR TITLE
BUILD: Added detekt to new multi-platform project `core/codes`

### DIFF
--- a/src/build.gradle.kts
+++ b/src/build.gradle.kts
@@ -6,4 +6,5 @@ plugins {
     alias(libs.plugins.androidLibrary)             apply false
     alias(libs.plugins.vanniktech.mavenPublish)    apply false
     alias(libs.plugins.ktlint)                     apply false
+    alias(libs.plugins.detekt)                     apply false
 }

--- a/src/core/codes/build.gradle.kts
+++ b/src/core/codes/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     alias(libs.plugins.androidLibrary)
     alias(libs.plugins.vanniktech.mavenPublish)
     alias(libs.plugins.ktlint)
+    alias(libs.plugins.detekt)
     id("signing")
 }
 
@@ -86,6 +87,16 @@ mavenPublishing {
             developerConnection = "scm:git:ssh://git@github.com/slatekit/kiit.git"
         }
     }
+}
+
+detekt {
+    config.setFrom("$projectDir/detekt.yml")
+    buildUponDefaultConfig = true
+    source.setFrom(
+        "src/commonMain/kotlin",
+        "src/jsMain/kotlin",
+        "src/iosMain/kotlin",
+    )
 }
 
 signing {

--- a/src/core/codes/detekt.yml
+++ b/src/core/codes/detekt.yml
@@ -1,0 +1,18 @@
+build:
+  maxIssues: 0
+
+config:
+  validation: true
+  warningsAsErrors: false
+
+style:
+  MagicNumber:
+    active: false        # status code integers are named constants, not magic numbers
+  MaxLineLength:
+    maxLineLength: 120
+  WildcardImport:
+    active: true
+  ReturnCount:
+    max: 6               # guard-clause early returns are idiomatic; default of 2 is too strict
+  ForbiddenComment:
+    active: false        # TODOs in KDoc are used as design notes, not untracked work

--- a/src/gradle/libs.versions.toml
+++ b/src/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ android-minSdk     = "24"
 android-compileSdk = "35"
 vanniktechMavenPublish = "0.34.0"
 ktlint                 = "12.1.2"
+detekt                 = "1.23.7"
 
 [libraries]
 kotlin-test            = { module = "org.jetbrains.kotlin:kotlin-test",              version.ref = "kotlin" }
@@ -20,3 +21,4 @@ kotlinMultiplatform        = { id = "org.jetbrains.kotlin.multiplatform",    ver
 androidLibrary             = { id = "com.android.library",                   version.ref = "agp"    }
 vanniktech-mavenPublish    = { id = "com.vanniktech.maven.publish",          version.ref = "vanniktechMavenPublish" }
 ktlint                     = { id = "org.jlleitschuh.gradle.ktlint",          version.ref = "ktlint"                }
+detekt                     = { id = "io.gitlab.arturbosch.detekt",             version.ref = "detekt"                }


### PR DESCRIPTION
## Overview
Added detekt to the new multi-platform project `core/codes`

## Example
Run from /src folder
```bash
# All configured sources (commonMain + jsMain + iosMain) — use this as the main check
./gradlew :core-codes:detekt

# Per source set / target
./gradlew :core-codes:detektMetadataCommonMain   # commonMain
./gradlew :core-codes:detektJsMain               # jsMain
./gradlew :core-codes:detektIosArm64Main         # iosMain (one slice)
./gradlew :core-codes:detektJvmMain              # JVM (experimental — includes type resolution)

# Generate a full default config to explore all available rules
./gradlew :core-codes:detektGenerateConfig

```

## Links(s) 
1. https://github.com/detekt/detekt

## Dependencies
1. **detejt** = `"1.23.7"`

## Design
See src/core/codes/detekt.yml
1. **Project** : `core/codes`

## Notes
n/a

## Pending
This will be added to all other projects afterwards.

## Tests
n/a
