### PR TITLE
BUILD: Added kover to new multi-platform project `core/codes`

### DIFF
--- a/src/build.gradle.kts
+++ b/src/build.gradle.kts
@@ -8,4 +8,5 @@ plugins {
     alias(libs.plugins.ktlint)                     apply false
     alias(libs.plugins.detekt)                     apply false
     alias(libs.plugins.dokka)                      apply false
+    alias(libs.plugins.kover)                      apply false
 }

--- a/src/core/codes/build.gradle.kts
+++ b/src/core/codes/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     alias(libs.plugins.ktlint)
     alias(libs.plugins.detekt)
     alias(libs.plugins.dokka)
+    alias(libs.plugins.kover)
     id("signing")
 }
 

--- a/src/core/codes/src/commonTest/kotlin/kiit/codes/CodesTest.kt
+++ b/src/core/codes/src/commonTest/kotlin/kiit/codes/CodesTest.kt
@@ -3,6 +3,9 @@ package kiit.codes
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 class CodesTest {

--- a/src/gradle/libs.versions.toml
+++ b/src/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ vanniktechMavenPublish = "0.34.0"
 ktlint                 = "12.1.2"
 detekt                 = "1.23.7"
 dokka                  = "2.0.0"
+kover                  = "0.9.1"
 
 [libraries]
 kotlin-test            = { module = "org.jetbrains.kotlin:kotlin-test",              version.ref = "kotlin" }
@@ -24,3 +25,4 @@ vanniktech-mavenPublish    = { id = "com.vanniktech.maven.publish",          ver
 ktlint                     = { id = "org.jlleitschuh.gradle.ktlint",          version.ref = "ktlint"                }
 detekt                     = { id = "io.gitlab.arturbosch.detekt",             version.ref = "detekt"                }
 dokka                      = { id = "org.jetbrains.dokka",                     version.ref = "dokka"                 }
+kover                      = { id = "org.jetbrains.kotlinx.kover",             version.ref = "kover"                 }


### PR DESCRIPTION
## Overview
Added kover for code coverage to the new multi-platform project `core/codes` 

## Example
Run from /src folder
```bash
# XML report (for CI / coverage tools)
./gradlew :core-codes:koverXmlReport    # → build/reports/kover/report.xml

# HTML report (browse locally)
./gradlew :core-codes:koverHtmlReport   # → build/reports/kover/html/index.html

# Enforce a minimum coverage threshold (add to build.gradle.kts if needed)
./gradlew :core-codes:koverVerify

```

## Links(s) 
1. https://github.com/Kotlin/kotlinx-kover

## Dependencies
1. **kover** = `"0.9.1"`

## Design
1. **Project**: `core/codes` 

## Notes
n/a

## Pending
n/a

## Tests
n/a
